### PR TITLE
Issue/1192 garden connection buttons

### DIFF
--- a/src/app/beer_garden/api/http/client.py
+++ b/src/app/beer_garden/api/http/client.py
@@ -5,10 +5,12 @@ from typing import Any, Optional
 
 import six
 from brewtils.models import BaseModel
+from brewtils.models import Garden as BrewtilsGarden
 from brewtils.schema_parser import SchemaParser
 
 import beer_garden.api
 import beer_garden.router
+from beer_garden.db.schemas.garden_schema import GardenSchema
 
 
 class SerializeHelper(object):
@@ -30,6 +32,9 @@ class SerializeHelper(object):
 
         if self.json_dump(result):
             return json.dumps(result) if serialize_kwargs["to_string"] else result
+
+        if isinstance(result, BrewtilsGarden):
+            return GardenSchema(strict=True).dumps(result).data
 
         return SchemaParser.serialize(result, **(serialize_kwargs or {}))
 

--- a/src/app/beer_garden/api/http/client.py
+++ b/src/app/beer_garden/api/http/client.py
@@ -30,11 +30,14 @@ class SerializeHelper(object):
         if serialize_kwargs.get("return_raw") or isinstance(result, six.string_types):
             return result
 
-        if self.json_dump(result):
-            return json.dumps(result) if serialize_kwargs["to_string"] else result
-
         if isinstance(result, BrewtilsGarden):
-            return GardenSchema(strict=True).dumps(result).data
+            return (
+                GardenSchema(strict=True).dumps(result).data
+                if serialize_kwargs["to_string"]
+                else GardenSchema(strict=True).dump(result).data
+            )
+        elif self.json_dump(result):
+            return json.dumps(result) if serialize_kwargs["to_string"] else result
 
         return SchemaParser.serialize(result, **(serialize_kwargs or {}))
 

--- a/src/app/beer_garden/db/mongo/api.py
+++ b/src/app/beer_garden/db/mongo/api.py
@@ -75,7 +75,13 @@ def from_brewtils(obj: ModelItem) -> MongoModel:
         The Mongo model item
 
     """
-    model_dict = SchemaParser.serialize(obj, to_string=False)
+    if isinstance(obj, brewtils.models.Garden):
+        # first step in decoupling from Brewtils
+        from beer_garden.db.schemas.garden_schema import GardenSchema
+
+        model_dict = GardenSchema(strict=True).dump(obj).data
+    else:
+        model_dict = SchemaParser.serialize(obj, to_string=False)
     mongo_obj = MongoParser.parse(model_dict, type(obj), from_string=False)
     return mongo_obj
 
@@ -108,8 +114,18 @@ def to_brewtils(
     if getattr(obj, "pre_serialize", None):
         obj.pre_serialize()
 
-    serialized = MongoParser.serialize(obj, to_string=True)
-    parsed = SchemaParser.parse(serialized, model_class, from_string=True, many=many)
+    if model_class == brewtils.models.Garden:
+        # first step in decoupling from Brewtils
+        from beer_garden.db.schemas.garden_schema import GardenSchema
+
+        schema = GardenSchema(strict=True)
+        serialized = schema.dumps(obj, many=many).data
+        parsed = schema.loads(serialized, many=many).data
+    else:
+        serialized = MongoParser.serialize(obj, to_string=True)
+        parsed = SchemaParser.parse(
+            serialized, model_class, from_string=True, many=many
+        )
 
     return parsed
 

--- a/src/app/beer_garden/db/schemas/garden_schema.py
+++ b/src/app/beer_garden/db/schemas/garden_schema.py
@@ -19,17 +19,13 @@ class GardenBaseSchema(Schema):
     def validate_all_keys(self, post_load_data, original_data, **kwargs):
         # do not allow extraneous keys when operating on a dictionary
         if isinstance(original_data, dict):
-            extra_args = original_data.keys() - post_load_data.keys()
-
+            extra_args = post_load_data.keys() - original_data.keys()
             if len(extra_args) > 0:
-                formatted_good_keys = ", ".join(
-                    map(lambda x: "'" + str(x) + "'", self.fields.keys())
-                )
-                formatted_bad_keys = ", ".join(
-                    map(lambda x: "'" + str(x) + "'", extra_args)
-                )
+                formatted_good_keys = ", ".join(self.fields.keys())
+                formatted_bad_keys = ", ".join(extra_args)
+                
                 raise ValidationError(
-                    f"Only {formatted_good_keys} allowed as keys; "
+                    f"Only {formatted_good_keys} allowed as keys - "
                     f"these are not allowed: {formatted_bad_keys}"
                 )
 

--- a/src/app/beer_garden/db/schemas/garden_schema.py
+++ b/src/app/beer_garden/db/schemas/garden_schema.py
@@ -1,0 +1,110 @@
+import logging
+
+from brewtils.models import Garden as BrewtilsGarden
+from brewtils.schemas import StatusInfoSchema  # noqa # until we can fully decouple
+from brewtils.schemas import SystemSchema  # noqa # until we can fully decouple
+from marshmallow import Schema, ValidationError, fields
+from marshmallow.decorators import post_load, pre_load, validates_schema
+from mongoengine.queryset.queryset import QuerySet
+
+logger = logging.getLogger(__name__)
+
+
+class GardenBaseSchema(Schema):
+    """Class to give Marshmallow Schemas the desired behavior of throwing
+    exceptions on errors when marshalling/unmarshalling. Otherwise, each line of code
+    utilizing these would need to pull apart MarshalResult objects in order to return
+    a meaningful error."""
+
+    @validates_schema(skip_on_field_errors=False, pass_original=True)
+    def validate_all_keys(self, post_load_data, original_data, **kwargs):
+        # do not allow extraneous keys when operating on a dictionary
+        if isinstance(original_data, dict):
+            extra_args = original_data.keys() - post_load_data.keys()
+
+            if len(extra_args) > 0:
+                formatted_good_keys = ", ".join(
+                    map(lambda x: "'" + str(x) + "'", self.fields.keys())
+                )
+                formatted_bad_keys = ", ".join(
+                    map(lambda x: "'" + str(x) + "'", extra_args)
+                )
+                raise ValidationError(
+                    f"Only {formatted_good_keys} allowed as keys; "
+                    f"these are not allowed: {formatted_bad_keys}"
+                )
+
+
+def _port_validator(value):
+    return 0 < value < 65535
+
+
+class HttpConnectionParamsSchema(GardenBaseSchema):
+    host = fields.String(required=True)
+    port = fields.Integer(
+        required=True,
+        validate=_port_validator,
+        error_messages={
+            **fields.Field.default_error_messages,
+            **{"validator_failed": "Value out of range for ports"},
+        },
+    )
+    url_prefix = fields.String(required=True, dump_default="/", load_default="/")
+    ca_cert = fields.String(required=False, allow_none=True)
+    ca_verify = fields.Boolean(required=True)
+    client_cert = fields.String(required=False, allow_none=True)
+    client_key = fields.String(required=False, allow_none=True)
+    ssl = fields.Boolean(required=True)
+
+
+class StompSSLParamsSchema(GardenBaseSchema):
+    use_ssl = fields.Boolean(required=True)
+
+
+class StompHeaderSchema(GardenBaseSchema):
+    key = fields.String(required=True)
+    value = fields.String(required=True)
+
+
+class StompConnectionParamsSchema(GardenBaseSchema):
+    ssl = fields.Nested("StompSSLParamsSchema", required=True)
+    headers = fields.List(fields.Nested("StompHeaderSchema"), required=False)
+    host = fields.String(required=True)
+    port = fields.Integer(
+        required=True,
+        validate=_port_validator,
+        error_messages={
+            **fields.Field.default_error_messages,
+            **{"validator_failed": "Value out of range for ports"},
+        },
+    )
+    send_destination = fields.String(required=False, allow_none=True)
+    subscribe_destination = fields.String(required=False, allow_none=True)
+    username = fields.String(required=False, allow_none=True)
+    password = fields.String(required=False, allow_none=True)
+
+
+class GardenConnectionsParamsSchema(GardenBaseSchema):
+    http = fields.Nested("HttpConnectionParamsSchema", allow_none=True)
+    stomp = fields.Nested("StompConnectionParamsSchema", allow_none=True)
+
+
+class GardenSchema(GardenBaseSchema):
+    id = fields.Str(allow_none=True)
+    # TODO the name field must be allowed to be blank for child garden registration
+    name = fields.Str(allow_none=False)
+    status = fields.Str(allow_none=True)
+    status_info = fields.Nested(StatusInfoSchema, allow_none=True)
+    connection_type = fields.Str(allow_none=False)
+    connection_params = fields.Nested(
+        "GardenConnectionsParamsSchema",
+        allow_none=True,
+        dump_default={},
+        load_default={},
+    )
+    namespaces = fields.List(fields.Str(), allow_none=True)
+    systems = fields.Nested(SystemSchema, many=True, allow_none=True)
+
+    @post_load
+    def make_object(self, data):
+        return BrewtilsGarden(**data)

--- a/src/app/beer_garden/db/schemas/garden_schema.py
+++ b/src/app/beer_garden/db/schemas/garden_schema.py
@@ -4,8 +4,7 @@ from brewtils.models import Garden as BrewtilsGarden
 from brewtils.schemas import StatusInfoSchema  # noqa # until we can fully decouple
 from brewtils.schemas import SystemSchema  # noqa # until we can fully decouple
 from marshmallow import Schema, ValidationError, fields
-from marshmallow.decorators import post_load, pre_load, validates_schema
-from mongoengine.queryset.queryset import QuerySet
+from marshmallow.decorators import post_load, validates_schema
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +94,7 @@ class GardenSchema(GardenBaseSchema):
     name = fields.Str(allow_none=False)
     status = fields.Str(allow_none=True)
     status_info = fields.Nested(StatusInfoSchema, allow_none=True)
-    connection_type = fields.Str(allow_none=False)
+    connection_type = fields.Str(allow_none=True)
     connection_params = fields.Nested(
         "GardenConnectionsParamsSchema",
         allow_none=True,

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -39,7 +39,7 @@ def garden_callbacks(event: Event) -> None:
         (beer_garden.garden.handle_event, "Garden"),
         (beer_garden.plugin.handle_event, "Plugin"),
         (beer_garden.requests.handle_event, "Request"),
-        (beer_garden.router.handle_event, "Rounter"),
+        (beer_garden.router.handle_event, "Router"),
         (beer_garden.systems.handle_event, "System"),
         (beer_garden.scheduler.handle_event, "Scheduler"),
         (beer_garden.log.handle_event, "Log"),

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -34,19 +34,22 @@ def garden_callbacks(event: Event) -> None:
         logger.debug(f"{event!r}")
 
     # These are all the MAIN PROCESS subsystems that care about events
-    for handler in [
-        beer_garden.application.handle_event,
-        beer_garden.garden.handle_event,
-        beer_garden.plugin.handle_event,
-        beer_garden.requests.handle_event,
-        beer_garden.router.handle_event,
-        beer_garden.systems.handle_event,
-        beer_garden.scheduler.handle_event,
-        beer_garden.log.handle_event,
-        beer_garden.files.handle_event,
-        beer_garden.local_plugins.manager.handle_event,
+    for handler, handler_tag in [
+        (beer_garden.application.handle_event, "Application"),
+        (beer_garden.garden.handle_event, "Garden"),
+        (beer_garden.plugin.handle_event, "Plugin"),
+        (beer_garden.requests.handle_event, "Request"),
+        (beer_garden.router.handle_event, "Rounter"),
+        (beer_garden.systems.handle_event, "System"),
+        (beer_garden.scheduler.handle_event, "Scheduler"),
+        (beer_garden.log.handle_event, "Log"),
+        (beer_garden.files.handle_event, "File"),
+        (beer_garden.local_plugins.manager.handle_event, "Local plugins manager"),
     ]:
         try:
             handler(deepcopy(event))
         except Exception as ex:
-            logger.exception(f"Error executing callback for {event!r}: {ex}")
+            logger.exception(
+                f"'{handler_tag}' event handler received an error executing callback"
+                f" for {event!r}: {ex}"
+            )

--- a/src/app/test/api/http/unit/handlers/v1/garden_connection_test.py
+++ b/src/app/test/api/http/unit/handlers/v1/garden_connection_test.py
@@ -1,0 +1,120 @@
+import json
+
+import pytest
+from tornado.httpclient import HTTPRequest, HTTPResponse
+
+from beer_garden.db.mongo.models import Garden
+from beer_garden.db.schemas.garden_schema import GardenSchema
+
+
+@pytest.fixture
+def http_connection_params():
+    return {
+        "http": {
+            "host": "somehost",
+            "port": 10001,
+            "url_prefix": "/",
+            "ca_verify": False,
+            "ssl": False,
+        }
+    }
+
+
+@pytest.fixture
+def stomp_connection_params():
+    return {
+        "stomp": {
+            "host": "somehost",
+            "port": 10001,
+            "ssl": {"use_ssl": False},
+            "headers": [],
+            "send_destination": "sendtohere",
+            "subscribe_destination": "listenhere",
+            "username": "stompuser",
+            "password": "stomppassword",
+        }
+    }
+
+
+@pytest.fixture
+def garden_with_http_connection_params(http_connection_params):
+    garden = Garden(
+        name="somehttpgardenname",
+        connection_type="HTTP",
+        connection_params=http_connection_params,
+    ).save()
+
+    yield garden
+
+    garden.delete()
+
+
+@pytest.fixture
+def garden_with_stomp_connection_params(stomp_connection_params):
+    garden = Garden(
+        name="somestompgardenname",
+        connection_type="STOMP",
+        connection_params=stomp_connection_params,
+    ).save()
+
+    yield garden
+
+    garden.delete()
+
+
+class TestGardenConnections:
+    @pytest.mark.parametrize(
+        "garden, required_fields, endpoint",
+        (
+            (
+                pytest.lazy_fixture("garden_with_http_connection_params"),
+                {"host", "port", "ssl"},
+                "http",
+            ),
+            (
+                pytest.lazy_fixture("garden_with_stomp_connection_params"),
+                {"host", "port"},
+                "stomp",
+            ),
+        ),
+    )
+    @pytest.mark.gen_test
+    def test_import_with_missing_required_params_returns_useful_message(
+        self,
+        garden,
+        required_fields,
+        endpoint,
+        http_client,
+        base_url,
+    ):
+        missing_data_message = "Missing data for required field."  # default marshmallow
+
+        endpoint_connection_params = garden.connection_params.pop(endpoint)
+        for required_field in required_fields:
+            _ = endpoint_connection_params.pop(required_field)
+
+        garden.connection_params = {endpoint: endpoint_connection_params}
+        patch_request_body = f"""{{"operations": [
+            {{
+                "operation": "config",
+                "value": {GardenSchema(strict=True).dumps(garden).data}
+            }}
+        ]}}
+        """
+
+        url = f"{base_url}/api/v1/gardens/" + garden.name
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+
+        request = HTTPRequest(
+            url, method="PATCH", headers=headers, body=patch_request_body
+        )
+
+        response: HTTPResponse
+        response = yield http_client.fetch(request, raise_error=False)
+        error_dict = json.loads(response.error.message.replace("'", '"'))[
+            "connection_params"
+        ][endpoint]
+
+        for field in required_fields:
+            assert field in error_dict
+            assert error_dict[field].pop() == missing_data_message

--- a/src/app/test/auth_test.py
+++ b/src/app/test/auth_test.py
@@ -113,7 +113,11 @@ def user_with_role_assignments(
 
 @pytest.fixture
 def test_garden(role_assignment_for_garden_scope):
-    garden = Garden(**role_assignment_for_garden_scope.domain.identifiers).save()
+    args = {
+        **{"connection_type": "LOCAL"},
+        **role_assignment_for_garden_scope.domain.identifiers,
+    }
+    garden = Garden(**args).save()
 
     yield garden
     garden.delete()

--- a/src/app/test/db/mongo/models/garden_model_test.py
+++ b/src/app/test/db/mongo/models/garden_model_test.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+import copy
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+from mongoengine import NotUniqueError, connect
+from mongoengine.errors import ValidationError
+
+from beer_garden.db.mongo.models import Garden, System
+
+v1_str = "v1"
+v2_str = "v2"
+garden_name = "test_garden"
+
+garbage_headers_extra_key = [
+    {
+        "key": "key_2",
+        "value": "value_2",
+        "extra_key": "value_doesnt_matter",
+    },
+]
+garbage_headers_wrong_key = [
+    {"notakey": "key_1", "value": "value_1"},
+]
+
+
+class TestGarden:
+    @classmethod
+    def setup_class(cls):
+        connect("beer_garden", host="mongomock://localhost")
+        Garden.drop_collection()
+        Garden.ensure_indexes()
+
+    @pytest.fixture()
+    def local_garden(self):
+        garden = Garden(name=garden_name, connection_type="LOCAL").save()
+        yield garden
+        garden.delete()
+
+    @pytest.fixture
+    def child_system(self):
+        return System(name="echoer", namespace="child_garden")
+
+    @pytest.fixture
+    def child_system_v1(self, child_system):
+        system: System = copy.deepcopy(child_system)
+        system.version = v1_str
+        system.save()
+        yield system
+        system.delete()
+
+    @pytest.fixture
+    def child_system_v2(self, child_system):
+        system: System = copy.deepcopy(child_system)
+        system.version = v2_str
+        system.save()
+        yield system
+        system.delete()
+
+    @pytest.fixture
+    def child_system_v1_diff_id(self, child_system):
+        system: System = copy.deepcopy(child_system)
+        system.version = v1_str
+        system.save()
+        yield system
+        system.delete()
+
+    @pytest.fixture
+    def child_garden(self, child_system_v1):
+        garden = Garden(
+            name="child_garden", connection_type="HTTP", systems=[child_system_v1]
+        ).save()
+        yield garden
+        garden.delete()
+
+    def test_garden_names_are_required_to_be_unique(self, local_garden):
+        """Attempting to create a garden that shares a name with an existing garden
+        should raise an exception"""
+        with pytest.raises(NotUniqueError):
+            Garden(name=local_garden.name, connection_type="HTTP").save()
+
+    def test_only_one_local_garden_may_exist(self, local_garden):
+        """Attempting to create more than one garden with connection_type of LOCAL
+        should raise an exception"""
+        with pytest.raises(NotUniqueError):
+            Garden(name=f"not{local_garden.name}", connection_type="LOCAL").save()
+
+    def test_child_garden_system_attrib_update(self, child_garden, child_system_v2):
+        """If the systems of a child garden are updated such that their names,
+        namespaces, or versions are changed, the original systems are removed and
+        replaced with the new systems when the garden is saved."""
+        orig_system_ids = set(
+            map(lambda x: str(getattr(x, "id")), child_garden.systems)  # noqa: B009
+        )
+        orig_system_versions = set(
+            map(
+                lambda x: str(getattr(x, "version")), child_garden.systems  # noqa: B009
+            )
+        )
+
+        assert v1_str in orig_system_versions and v2_str not in orig_system_versions
+
+        child_garden.systems = [child_system_v2]
+        child_garden.deep_save()
+
+        # we check that the garden written to the DB has the correct systems
+        db_garden = Garden.objects().first()
+
+        new_system_ids = set(
+            map(lambda x: str(getattr(x, "id")), db_garden.systems)  # noqa: B009
+        )
+        new_system_versions = set(
+            map(lambda x: str(getattr(x, "version")), db_garden.systems)  # noqa: B009
+        )
+
+        assert v1_str not in new_system_versions and v2_str in new_system_versions
+        assert new_system_ids.intersection(orig_system_ids) == set()
+
+    def test_child_garden_system_id_update(self, child_garden, child_system_v1_diff_id):
+        """If the systems of a child garden are updated such that the names, namespaces
+        and versions remain constant, but the IDs are different, the original systms
+        are removed and replaced with the new systems when the garden is saved."""
+        orig_system_ids = set(
+            map(lambda x: str(getattr(x, "id")), child_garden.systems)  # noqa: B009
+        )
+        new_system_id = str(child_system_v1_diff_id.id)
+
+        assert new_system_id not in orig_system_ids
+
+        child_garden.systems = [child_system_v1_diff_id]
+        child_garden.deep_save()
+        db_garden = Garden.objects().first()
+
+        new_system_ids = set(
+            map(lambda x: str(getattr(x, "id")), db_garden.systems)  # noqa: B009
+        )
+
+        assert new_system_id in new_system_ids
+        assert orig_system_ids.intersection(new_system_ids) == set()
+
+
+class TestGardenConnectionParameters:
+    @classmethod
+    def setup_class(cls):
+        connect("beer_garden", host="mongomock://localhost")
+        Garden.drop_collection()
+        Garden.ensure_indexes()
+
+    @pytest.fixture(autouse=True)
+    def drop(self):
+        Garden.drop_collection()
+
+    @pytest.fixture
+    def bad_conn_params(self):
+        return dict([("nonempty", "dictionaries"), ("should", "fail")])
+
+    @pytest.fixture
+    def http_conn_params(self):
+        return {
+            "http": {
+                "port": 2337,
+                "ssl": True,
+                "url_prefix": "/",
+                "ca_verify": True,
+                "host": "bg-child1",
+            }
+        }
+
+    @pytest.fixture
+    def stomp_conn_params_basic(self):
+        return {
+            "stomp": {
+                "ssl": {"use_ssl": False},
+                "headers": [],
+                "host": "activemq",
+                "port": 61613,
+                "send_destination": "send_destination",
+                "subscribe_destination": "subscribe_destination",
+                "username": "beer_garden",
+                "password": "password",
+            }
+        }
+
+    @pytest.fixture
+    def stomp_conn_params_with_headers(self, stomp_conn_params_basic):
+        stomp_conn_params = copy.deepcopy(stomp_conn_params_basic)
+        headers = [{"key": f"key_{i+1}", "value": f"value_{i+1}"} for i in range(3)]
+        stomp_conn_params["stomp"]["headers"] = headers
+        return stomp_conn_params
+
+    @pytest.fixture
+    def bad_conn_params_with_partial_good(self, http_conn_params, bad_conn_params):
+        return {**http_conn_params, **bad_conn_params}
+
+    @pytest.fixture
+    def bad_conn_params_with_full_good(
+        self, bad_conn_params_with_partial_good, stomp_conn_params_basic
+    ):
+        return {**stomp_conn_params_basic, **bad_conn_params_with_partial_good}
+
+    @pytest.mark.parametrize(
+        "conn_parm",
+        (
+            pytest.lazy_fixture("bad_conn_params"),
+            pytest.lazy_fixture("bad_conn_params_with_partial_good"),
+            pytest.lazy_fixture("bad_conn_params_with_full_good"),
+        ),
+    )
+    def test_local_garden_save_fails_with_nonempty_conn_params(self, conn_parm):
+        with pytest.raises(ValidationError) as excinfo:
+            Garden(
+                name=garden_name,
+                connection_type="LOCAL",
+                connection_params=conn_parm,
+            ).save()
+        assert "not allowed" in str(excinfo.value)
+
+    def test_local_garden_save_succeeds_with_empty_conn_params(self):
+        with does_not_raise():
+            Garden(
+                name=garden_name, connection_type="LOCAL", connection_params={}
+            ).save().delete()
+
+    @pytest.mark.parametrize(
+        "conn_parm",
+        (
+            pytest.lazy_fixture("bad_conn_params"),
+            # pytest.lazy_fixture("bad_conn_params_with_partial_good"),
+            # pytest.lazy_fixture("bad_conn_params_with_full_good"),
+        ),
+    )
+    def test_remote_garden_save_fails_with_bad_conn_params(self, conn_parm):
+        with pytest.raises(ValidationError) as excinfo:
+            Garden(
+                name=garden_name,
+                connection_type="HTTP",
+                connection_params=conn_parm,
+            ).save()
+        assert "not allowed" in str(excinfo.value)
+
+    @pytest.mark.parametrize("required", ("port", "ssl", "ca_verify", "host"))
+    def test_required_http_params_missing_fails(self, http_conn_params, required):
+        conn_param_values = http_conn_params["http"]
+        _ = conn_param_values.pop(required)
+        conn_params = {"http": conn_param_values}
+
+        with pytest.raises(ValidationError) as excinfo:
+            Garden(
+                name=garden_name, connection_type="HTTP", connection_params=conn_params
+            ).save()
+        assert "Missing data" in str(excinfo.value)
+
+    @pytest.mark.parametrize("required", ("ssl", "host", "port"))
+    def test_required_stomp_params_missing_fails(
+        self, stomp_conn_params_basic, required
+    ):
+        conn_param_values = stomp_conn_params_basic["stomp"]
+        _ = conn_param_values.pop(required)
+        conn_params = {"stomp": conn_param_values}
+
+        with pytest.raises(ValidationError) as excinfo:
+            Garden(
+                name=garden_name, connection_type="HTTP", connection_params=conn_params
+            ).save()
+        assert "Missing data" in str(excinfo.value)
+
+    def test_remote_garden_save_succeeds_with_only_good_http_headers(
+        self, http_conn_params
+    ):
+        garden = Garden(
+            name=garden_name,
+            connection_type="HTTP",
+            connection_params=http_conn_params,
+        )
+        with does_not_raise():
+            garden.save()
+        garden.delete()
+
+    def test_remote_garden_save_succeeds_with_only_good_stomp_headers(
+        self, stomp_conn_params_with_headers
+    ):
+        garden = Garden(
+            name=garden_name,
+            connection_type="STOMP",
+            connection_params=stomp_conn_params_with_headers,
+        )
+        with does_not_raise():
+            garden.save()
+        garden.delete()
+
+    @pytest.mark.parametrize(
+        "bad_headers",
+        (
+            garbage_headers_extra_key,
+            # garbage_headers_wrong_key,
+        ),
+    )
+    def test_remote_garden_save_fails_with_garbage_stomp_headers(
+        self, stomp_conn_params_basic, bad_headers
+    ):
+        test_params = stomp_conn_params_basic["stomp"]
+        test_params["headers"] = bad_headers
+        connection_params = {"stomp": test_params}
+
+        with pytest.raises(ValidationError) as exc:
+            Garden(
+                name=garden_name,
+                connection_type="STOMP",
+                connection_params=connection_params,
+            ).save()

--- a/src/app/test/db/mongo/models/garden_model_test.py
+++ b/src/app/test/db/mongo/models/garden_model_test.py
@@ -225,8 +225,8 @@ class TestGardenConnectionParameters:
         "conn_parm",
         (
             pytest.lazy_fixture("bad_conn_params"),
-            # pytest.lazy_fixture("bad_conn_params_with_partial_good"),
-            # pytest.lazy_fixture("bad_conn_params_with_full_good"),
+            pytest.lazy_fixture("bad_conn_params_with_partial_good"),
+            pytest.lazy_fixture("bad_conn_params_with_full_good"),
         ),
     )
     def test_remote_garden_save_fails_with_bad_conn_params(self, conn_parm):
@@ -292,7 +292,7 @@ class TestGardenConnectionParameters:
         "bad_headers",
         (
             garbage_headers_extra_key,
-            # garbage_headers_wrong_key,
+            garbage_headers_wrong_key,
         ),
     )
     def test_remote_garden_save_fails_with_garbage_stomp_headers(
@@ -302,7 +302,7 @@ class TestGardenConnectionParameters:
         test_params["headers"] = bad_headers
         connection_params = {"stomp": test_params}
 
-        with pytest.raises(ValidationError) as exc:
+        with pytest.raises(ValidationError):
             Garden(
                 name=garden_name,
                 connection_type="STOMP",

--- a/src/app/test/db/mongo/models/models_test.py
+++ b/src/app/test/db/mongo/models/models_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
 from datetime import datetime, timedelta
 from uuid import uuid4
 
@@ -18,7 +17,6 @@ from beer_garden.db.mongo.models import (
     Command,
     CommandPublishingBlockList,
     DateTrigger,
-    Garden,
     Instance,
     Job,
     Parameter,
@@ -722,138 +720,3 @@ class TestCommandBlockList:
             CommandPublishingBlockList(
                 namespace=self.namespace, system=self.system, command=self.command
             ).save()
-
-
-class TestGarden:
-    v1_str = "v1"
-    v2_str = "v2"
-    garden_name = "test_garden"
-
-    @classmethod
-    def setup_class(cls):
-        connect("beer_garden", host="mongomock://localhost")
-        Garden.drop_collection()
-        Garden.ensure_indexes()
-
-    @pytest.fixture()
-    def local_garden(self, mongo_conn):
-        garden = Garden(name=self.garden_name, connection_type="LOCAL").save()
-
-        yield garden
-
-        garden.delete()
-
-    @pytest.fixture
-    def child_system(self):
-        return System(name="echoer", namespace="child_garden")
-
-    @pytest.fixture
-    def child_system_v1(self, child_system):
-        system: System = copy.deepcopy(child_system)
-        system.version = self.v1_str
-        system.save()
-
-        yield system
-
-        system.delete()
-
-    @pytest.fixture
-    def child_system_v2(self, child_system):
-        system: System = copy.deepcopy(child_system)
-        system.version = self.v2_str
-        system.save()
-
-        yield system
-
-        system.delete()
-
-    @pytest.fixture
-    def child_system_v1_diff_id(self, child_system):
-        system: System = copy.deepcopy(child_system)
-        system.version = self.v1_str
-        system.save()
-
-        yield system
-
-        system.delete()
-
-    @pytest.fixture
-    def child_garden(self, child_system_v1):
-        garden = Garden(
-            name="child_garden", connection_type="http", systems=[child_system_v1]
-        ).save()
-
-        yield garden
-
-        garden.delete()
-
-    def test_garden_names_are_required_to_be_unique(self, local_garden):
-        """Attempting to create a garden that shares a name with an existing garden
-        should raise an exception"""
-        with pytest.raises(NotUniqueError):
-            Garden(name=local_garden.name, connection_type="HTTP").save()
-
-    def test_only_one_local_garden_may_exist(self, local_garden):
-        """Attempting to create more than one garden with connection_type of LOCAL
-        should raise an exception"""
-        with pytest.raises(NotUniqueError):
-            Garden(name=f"not{local_garden.name}", connection_type="LOCAL").save()
-
-    def test_child_garden_system_attrib_update(self, child_garden, child_system_v2):
-        """If the systems of a child garden are updated such that their names,
-        namespaces, or versions are changed, the original systems are removed and
-        replaced with the new systems when the garden is saved."""
-        orig_system_ids = set(
-            map(lambda x: str(getattr(x, "id")), child_garden.systems)  # noqa: B009
-        )
-        orig_system_versions = set(
-            map(
-                lambda x: str(getattr(x, "version")), child_garden.systems  # noqa: B009
-            )
-        )
-
-        assert (
-            self.v1_str in orig_system_versions
-            and self.v2_str not in orig_system_versions
-        )
-
-        child_garden.systems = [child_system_v2]
-        child_garden.deep_save()
-
-        # we check that the garden written to the DB has the correct systems
-        db_garden = Garden.objects().first()
-
-        new_system_ids = set(
-            map(lambda x: str(getattr(x, "id")), db_garden.systems)  # noqa: B009
-        )
-        new_system_versions = set(
-            map(lambda x: str(getattr(x, "version")), db_garden.systems)  # noqa: B009
-        )
-
-        assert (
-            self.v1_str not in new_system_versions
-            and self.v2_str in new_system_versions
-        )
-        assert new_system_ids.intersection(orig_system_ids) == set()
-
-    def test_child_garden_system_id_update(self, child_garden, child_system_v1_diff_id):
-        """If the systems of a child garden are updated such that the names, namespaces
-        and versions remain constant, but the IDs are different, the original systms
-        are removed and replaced with the new systems when the garden is saved."""
-        orig_system_ids = set(
-            map(lambda x: str(getattr(x, "id")), child_garden.systems)  # noqa: B009
-        )
-        new_system_id = str(child_system_v1_diff_id.id)
-
-        assert new_system_id not in orig_system_ids
-
-        child_garden.systems = [child_system_v1_diff_id]
-        child_garden.deep_save()
-        db_garden = Garden.objects().first()
-
-        new_system_ids = set(
-            map(lambda x: str(getattr(x, "id")), db_garden.systems)  # noqa: B009
-        )
-
-        assert new_system_id in new_system_ids
-        assert orig_system_ids.intersection(new_system_ids) == set()

--- a/src/app/test/garden_test.py
+++ b/src/app/test/garden_test.py
@@ -2,9 +2,7 @@
 import pytest
 from brewtils.models import Garden as BrewtilsGarden
 from brewtils.models import System as BrewtilsSystem
-from brewtils.specification import _CONNECTION_SPEC
 from mongoengine import DoesNotExist, connect
-from yapconf import YapconfSpec
 
 from beer_garden import config
 from beer_garden.db.mongo.models import Garden, System

--- a/src/ui/.eslintrc.json
+++ b/src/ui/.eslintrc.json
@@ -9,7 +9,7 @@
       "es6": true
     },
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 2018,
       "sourceType": "module"
     }
 }

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -110,6 +110,11 @@ import {
 } from './js/controllers/admin_role.js';
 import adminGardenController from './js/controllers/admin_garden.js';
 import adminGardenViewController from './js/controllers/admin_garden_view.js';
+import {
+  gardenConfigImportController,
+  gardenConfigImportModalController,
+} from './js/controllers/garden/import_garden_config';
+import gardenConfigExportController from './js/controllers/garden/export_garden_config';
 import commandIndexController from './js/controllers/command_index.js';
 import commandViewController from './js/controllers/command_view.js';
 import requestIndexController from './js/controllers/request_index.js';
@@ -210,7 +215,7 @@ angular
     .controller('AdminQueueController', adminQueueController)
     .controller(
         'AdminSystemForceDeleteController',
-        adminSystemForceDeleteController
+        adminSystemForceDeleteController,
     )
     .controller('AdminSystemController', adminSystemController)
     .controller('AdminSystemLogsController', adminSystemLogsController)
@@ -220,6 +225,9 @@ angular
     .controller('NewRoleController', newRoleController)
     .controller('AdminGardenController', adminGardenController)
     .controller('AdminGardenViewController', adminGardenViewController)
+    .controller('GardenConfigExportController', gardenConfigExportController)
+    .controller('GardenConfigImportController', gardenConfigImportController)
+    .controller('GardenConfigImportModalController', gardenConfigImportModalController)
     .controller('CommandIndexController', commandIndexController)
     .controller('CommandViewController', commandViewController)
     .controller('RequestIndexController', requestIndexController)

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -1,238 +1,238 @@
-"use strict";
+'use strict';
 
 // Javascript
 // Utilities
-import "babel-polyfill";
-import "objectpath";
-import "tv4";
-import "jquery";
+import 'babel-polyfill';
+import 'objectpath';
+import 'tv4';
+import 'jquery';
 
-import moment from "moment";
-import "moment-timezone";
-moment.tz.setDefault("UTC");
+import moment from 'moment';
+import 'moment-timezone';
+moment.tz.setDefault('UTC');
 
 // Angular
-import angular from "angular";
-import "angular-animate";
-import "angular-confirm";
-import "angular-filter";
-import "angular-sanitize";
-import "angular-ui-ace";
-import "angular-ui-bootstrap";
-import "@uirouter/angularjs";
-import "angular-bootstrap-switch";
-import "angular-strap";
-import "angular-local-storage";
+import angular from 'angular';
+import 'angular-animate';
+import 'angular-confirm';
+import 'angular-filter';
+import 'angular-sanitize';
+import 'angular-ui-ace';
+import 'angular-ui-bootstrap';
+import '@uirouter/angularjs';
+import 'angular-bootstrap-switch';
+import 'angular-strap';
+import 'angular-local-storage';
 
-import "bootstrap";
-import "bootstrap-switch";
-import "eonasdan-bootstrap-datetimepicker";
-import "ui-select";
-import "metismenu";
-import "startbootstrap-sb-admin-2/js/sb-admin-2.js";
-import "datatables.net";
-import "datatables.net-bs";
-import "datatables-columnfilter";
-import "datatables-columnfilter/dist/dataTables.lcf.eonasdan.js";
-import "jwt-decode";
-import "angular-datatables/dist/angular-datatables.js";
-import "angular-datatables/dist/plugins/light-columnfilter/angular-datatables.light-columnfilter.js"; // eslint-disable-line max-len
-import "angular-datatables/dist/plugins/bootstrap/angular-datatables.bootstrap.js";
-import "angular-schema-form-bootstrap/dist/angular-schema-form-bootstrap-bundled.js";
-import "ace-builds/src-noconflict/ace.js";
-import "ace-builds/src-noconflict/mode-json.js";
-import "ace-builds/src-noconflict/theme-dawn.js";
+import 'bootstrap';
+import 'bootstrap-switch';
+import 'eonasdan-bootstrap-datetimepicker';
+import 'ui-select';
+import 'metismenu';
+import 'startbootstrap-sb-admin-2/js/sb-admin-2.js';
+import 'datatables.net';
+import 'datatables.net-bs';
+import 'datatables-columnfilter';
+import 'datatables-columnfilter/dist/dataTables.lcf.eonasdan.js';
+import 'jwt-decode';
+import 'angular-datatables/dist/angular-datatables.js';
+import 'angular-datatables/dist/plugins/light-columnfilter/angular-datatables.light-columnfilter.js'; // eslint-disable-line max-len
+import 'angular-datatables/dist/plugins/bootstrap/angular-datatables.bootstrap.js';
+import 'angular-schema-form-bootstrap/dist/angular-schema-form-bootstrap-bundled.js';
+import 'ace-builds/src-noconflict/ace.js';
+import 'ace-builds/src-noconflict/mode-json.js';
+import 'ace-builds/src-noconflict/theme-dawn.js';
 
 // Our ASF addons and builder
-import "@beer-garden/builder";
-import "@beer-garden/addons";
+import '@beer-garden/builder';
+import '@beer-garden/addons';
 
 // TODO - This needs to be served separately right now, something about WebWorkers?
 // require('ace-builds/src-noconflict/worker-json.js');
 
 // CSS
-import "bootstrap/dist/css/bootstrap.css";
-import "bootstrap/dist/css/bootstrap-theme.css";
-import "bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css";
-import "metismenu/dist/metisMenu.css";
-import "startbootstrap-sb-admin-2/dist/css/sb-admin-2.css";
-import "datatables.net-bs/css/dataTables.bootstrap.css";
-import "ui-select/dist/select.css";
-import "font-awesome/css/font-awesome.css";
-import "./styles/custom.css";
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/dist/css/bootstrap-theme.css';
+import 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css';
+import 'metismenu/dist/metisMenu.css';
+import 'startbootstrap-sb-admin-2/dist/css/sb-admin-2.css';
+import 'datatables.net-bs/css/dataTables.bootstrap.css';
+import 'ui-select/dist/select.css';
+import 'font-awesome/css/font-awesome.css';
+import './styles/custom.css';
 
 // Now load our actual application components
-import appRun from "./js/run.js";
-import runDTRenderer from "./js/configs/dt_renderer.js";
-import routeConfig from "./js/configs/routes.js";
+import appRun from './js/run.js';
+import runDTRenderer from './js/configs/dt_renderer.js';
+import routeConfig from './js/configs/routes.js';
 import {
   interceptorService,
   authInterceptorService,
   interceptorConfig,
-} from "./js/configs/http_interceptor.js";
+} from './js/configs/http_interceptor.js';
 
-import { compilerConfig } from "./js/configs/compiler_config.js";
+import {compilerConfig} from './js/configs/compiler_config.js';
 
-import fetchDataDirective from "./js/directives/fetch_data.js";
-import bgStatusDirective from "./js/directives/system_status.js";
-import customOnChangeDirective from "./js/directives/custom_on_change.js";
+import fetchDataDirective from './js/directives/fetch_data.js';
+import bgStatusDirective from './js/directives/system_status.js';
+import customOnChangeDirective from './js/directives/custom_on_change.js';
 
-import adminService from "./js/services/admin_service.js";
-import commandService from "./js/services/command_service.js";
-import instanceService from "./js/services/instance_service.js";
-import queueService from "./js/services/queue_service.js";
-import requestService from "./js/services/request_service.js";
-import systemService from "./js/services/system_service.js";
-import userService from "./js/services/user_service.js";
-import roleService from "./js/services/role_service.js";
-import permissionService from "./js/services/permission_service.js";
-import tokenService from "./js/services/token_service.js";
-import utilityService from "./js/services/utility_service.js";
-import jobService from "./js/services/job_service.js";
-import errorService from "./js/services/error_service.js";
-import eventService from "./js/services/event_service.js";
-import namespaceService from "./js/services/namespace_service.js";
-import gardenService from "./js/services/garden_service.js";
-import runnerService from "./js/services//runner_service.js";
+import adminService from './js/services/admin_service.js';
+import commandService from './js/services/command_service.js';
+import instanceService from './js/services/instance_service.js';
+import queueService from './js/services/queue_service.js';
+import requestService from './js/services/request_service.js';
+import systemService from './js/services/system_service.js';
+import userService from './js/services/user_service.js';
+import roleService from './js/services/role_service.js';
+import permissionService from './js/services/permission_service.js';
+import tokenService from './js/services/token_service.js';
+import utilityService from './js/services/utility_service.js';
+import jobService from './js/services/job_service.js';
+import errorService from './js/services/error_service.js';
+import eventService from './js/services/event_service.js';
+import namespaceService from './js/services/namespace_service.js';
+import gardenService from './js/services/garden_service.js';
+import runnerService from './js/services//runner_service.js';
 
-import aboutController from "./js/controllers/about.js";
-import adminQueueController from "./js/controllers/admin_queue.js";
-import adminSystemController from "./js/controllers/admin_system.js";
-import adminSystemLogsController from "./js/controllers/admin_system_logs.js";
-import adminSystemForceDeleteController from "./js/controllers/admin_system_force_delete.js";
+import aboutController from './js/controllers/about.js';
+import adminQueueController from './js/controllers/admin_queue.js';
+import adminSystemController from './js/controllers/admin_system.js';
+import adminSystemLogsController from './js/controllers/admin_system_logs.js';
+import adminSystemForceDeleteController from './js/controllers/admin_system_force_delete.js';
 import {
   adminUserController,
   newUserController,
-} from "./js/controllers/admin_user.js";
+} from './js/controllers/admin_user.js';
 import {
   adminRoleController,
   newRoleController,
-} from "./js/controllers/admin_role.js";
-import adminGardenController from "./js/controllers/admin_garden.js";
-import adminGardenViewController from "./js/controllers/admin_garden_view.js";
-import commandIndexController from "./js/controllers/command_index.js";
-import commandViewController from "./js/controllers/command_view.js";
-import requestIndexController from "./js/controllers/request_index.js";
+} from './js/controllers/admin_role.js';
+import adminGardenController from './js/controllers/admin_garden.js';
+import adminGardenViewController from './js/controllers/admin_garden_view.js';
+import commandIndexController from './js/controllers/command_index.js';
+import commandViewController from './js/controllers/command_view.js';
+import requestIndexController from './js/controllers/request_index.js';
 import requestViewController, {
   slideAnimation,
-} from "./js/controllers/request_view.js";
-import systemIndexController from "./js/controllers/system_index.js";
-import jobIndexController from "./js/controllers/job_index.js";
+} from './js/controllers/request_view.js';
+import systemIndexController from './js/controllers/system_index.js';
+import jobIndexController from './js/controllers/job_index.js';
 import {
   jobViewController,
   jobRunNowModalController,
-} from "./js/controllers/job_view.js";
-import jobCreateSystemController from "./js/controllers/job/create_system.js";
-import jobExportController from "./js/controllers/job/export_jobs.js";
+} from './js/controllers/job_view.js';
+import jobCreateSystemController from './js/controllers/job/create_system.js';
+import jobExportController from './js/controllers/job/export_jobs.js';
 import {
   jobImportController,
   jobImportModalController,
-} from "./js/controllers/job/import_jobs.js";
-import jobCreateCommandController from "./js/controllers/job/create_command.js";
-import jobCreateRequestController from "./js/controllers/job/create_request.js";
-import jobCreateTriggerController from "./js/controllers/job/create_trigger.js";
-import loginController from "./js/controllers/login.js";
+} from './js/controllers/job/import_jobs.js';
+import jobCreateCommandController from './js/controllers/job/create_command.js';
+import jobCreateRequestController from './js/controllers/job/create_request.js';
+import jobCreateTriggerController from './js/controllers/job/create_trigger.js';
+import loginController from './js/controllers/login.js';
 
 // Partials
-import "./partials/about.html";
-import "./partials/admin_system.html";
-import "./partials/admin_user.html";
-import "./partials/admin_role.html";
-import "./partials/admin_garden_index.html";
-import "./partials/admin_garden_view.html";
-import "./partials/command_index.html";
-import "./partials/command_view.html";
-import "./partials/request_index.html";
-import "./partials/request_view.html";
-import "./partials/system_index.html";
-import "./partials/job_index.html";
-import "./partials/job_view.html";
-import "./partials/job/create_system.html";
-import "./partials/job/create_command.html";
-import "./partials/job/create_request.html";
-import "./partials/job/create_trigger.html";
+import './partials/about.html';
+import './partials/admin_system.html';
+import './partials/admin_user.html';
+import './partials/admin_role.html';
+import './partials/admin_garden_index.html';
+import './partials/admin_garden_view.html';
+import './partials/command_index.html';
+import './partials/command_view.html';
+import './partials/request_index.html';
+import './partials/request_view.html';
+import './partials/system_index.html';
+import './partials/job_index.html';
+import './partials/job_view.html';
+import './partials/job/create_system.html';
+import './partials/job/create_command.html';
+import './partials/job/create_request.html';
+import './partials/job/create_trigger.html';
 
 // Images
-import "./image/fa-beer.png";
-import "./image/fa-coffee.png";
+import './image/fa-beer.png';
+import './image/fa-coffee.png';
 
 // Finally, FINALLY, we have all our dependencies imported. Create the Angularness!
 angular
-  .module("bgApp", [
-    "ui.router",
-    "ui.bootstrap",
-    "ui.ace",
-    "datatables",
-    "datatables.bootstrap",
-    "datatables.light-columnfilter",
-    "schemaForm",
-    "angular-confirm",
-    "angular.filter",
-    "ngAnimate",
-    "frapontillo.bootstrap-switch",
-    "mgcrea.ngStrap",
-    "LocalStorageModule",
-    "beer-garden.addons",
-    "beer-garden.builder",
-  ])
-  .run(appRun)
-  .run(runDTRenderer)
-  .config(routeConfig)
-  .config(interceptorConfig)
-  .config(compilerConfig)
-  .service("APIInterceptor", interceptorService)
-  .service("authInterceptorService", authInterceptorService)
-  .animation(".slide", slideAnimation)
+    .module('bgApp', [
+      'ui.router',
+      'ui.bootstrap',
+      'ui.ace',
+      'datatables',
+      'datatables.bootstrap',
+      'datatables.light-columnfilter',
+      'schemaForm',
+      'angular-confirm',
+      'angular.filter',
+      'ngAnimate',
+      'frapontillo.bootstrap-switch',
+      'mgcrea.ngStrap',
+      'LocalStorageModule',
+      'beer-garden.addons',
+      'beer-garden.builder',
+    ])
+    .run(appRun)
+    .run(runDTRenderer)
+    .config(routeConfig)
+    .config(interceptorConfig)
+    .config(compilerConfig)
+    .service('APIInterceptor', interceptorService)
+    .service('authInterceptorService', authInterceptorService)
+    .animation('.slide', slideAnimation)
 
-  .directive("fetchData", fetchDataDirective)
-  .directive("bgStatus", bgStatusDirective)
-  .directive("customOnChange", customOnChangeDirective)
+    .directive('fetchData', fetchDataDirective)
+    .directive('bgStatus', bgStatusDirective)
+    .directive('customOnChange', customOnChangeDirective)
 
-  .factory("AdminService", adminService)
-  .factory("CommandService", commandService)
-  .factory("InstanceService", instanceService)
-  .factory("QueueService", queueService)
-  .factory("RequestService", requestService)
-  .factory("SystemService", systemService)
-  .factory("UserService", userService)
-  .factory("RoleService", roleService)
-  .factory("PermissionService", permissionService)
-  .factory("TokenService", tokenService)
-  .factory("UtilityService", utilityService)
-  .factory("JobService", jobService)
-  .factory("ErrorService", errorService)
-  .factory("EventService", eventService)
-  .factory("NamespaceService", namespaceService)
-  .factory("GardenService", gardenService)
-  .factory("RunnerService", runnerService)
+    .factory('AdminService', adminService)
+    .factory('CommandService', commandService)
+    .factory('InstanceService', instanceService)
+    .factory('QueueService', queueService)
+    .factory('RequestService', requestService)
+    .factory('SystemService', systemService)
+    .factory('UserService', userService)
+    .factory('RoleService', roleService)
+    .factory('PermissionService', permissionService)
+    .factory('TokenService', tokenService)
+    .factory('UtilityService', utilityService)
+    .factory('JobService', jobService)
+    .factory('ErrorService', errorService)
+    .factory('EventService', eventService)
+    .factory('NamespaceService', namespaceService)
+    .factory('GardenService', gardenService)
+    .factory('RunnerService', runnerService)
 
-  .controller("AboutController", aboutController)
-  .controller("AdminQueueController", adminQueueController)
-  .controller(
-    "AdminSystemForceDeleteController",
-    adminSystemForceDeleteController
-  )
-  .controller("AdminSystemController", adminSystemController)
-  .controller("AdminSystemLogsController", adminSystemLogsController)
-  .controller("AdminUserController", adminUserController)
-  .controller("NewUserController", newUserController)
-  .controller("AdminRoleController", adminRoleController)
-  .controller("NewRoleController", newRoleController)
-  .controller("AdminGardenController", adminGardenController)
-  .controller("AdminGardenViewController", adminGardenViewController)
-  .controller("CommandIndexController", commandIndexController)
-  .controller("CommandViewController", commandViewController)
-  .controller("RequestIndexController", requestIndexController)
-  .controller("RequestViewController", requestViewController)
-  .controller("SystemIndexController", systemIndexController)
-  .controller("JobIndexController", jobIndexController)
-  .controller("JobViewController", jobViewController)
-  .controller("JobRunNowModalController", jobRunNowModalController)
-  .controller("JobCreateSystemController", jobCreateSystemController)
-  .controller("JobCreateCommandController", jobCreateCommandController)
-  .controller("JobCreateRequestController", jobCreateRequestController)
-  .controller("JobCreateTriggerController", jobCreateTriggerController)
-  .controller("JobExportController", jobExportController)
-  .controller("JobImportController", jobImportController)
-  .controller("JobImportModalController", jobImportModalController)
-  .controller("LoginController", loginController);
+    .controller('AboutController', aboutController)
+    .controller('AdminQueueController', adminQueueController)
+    .controller(
+        'AdminSystemForceDeleteController',
+        adminSystemForceDeleteController
+    )
+    .controller('AdminSystemController', adminSystemController)
+    .controller('AdminSystemLogsController', adminSystemLogsController)
+    .controller('AdminUserController', adminUserController)
+    .controller('NewUserController', newUserController)
+    .controller('AdminRoleController', adminRoleController)
+    .controller('NewRoleController', newRoleController)
+    .controller('AdminGardenController', adminGardenController)
+    .controller('AdminGardenViewController', adminGardenViewController)
+    .controller('CommandIndexController', commandIndexController)
+    .controller('CommandViewController', commandViewController)
+    .controller('RequestIndexController', requestIndexController)
+    .controller('RequestViewController', requestViewController)
+    .controller('SystemIndexController', systemIndexController)
+    .controller('JobIndexController', jobIndexController)
+    .controller('JobViewController', jobViewController)
+    .controller('JobRunNowModalController', jobRunNowModalController)
+    .controller('JobCreateSystemController', jobCreateSystemController)
+    .controller('JobCreateCommandController', jobCreateCommandController)
+    .controller('JobCreateRequestController', jobCreateRequestController)
+    .controller('JobCreateTriggerController', jobCreateTriggerController)
+    .controller('JobExportController', jobExportController)
+    .controller('JobImportController', jobImportController)
+    .controller('JobImportModalController', jobImportModalController)
+    .controller('LoginController', loginController);

--- a/src/ui/src/js/configs/compiler_config.js
+++ b/src/ui/src/js/configs/compiler_config.js
@@ -5,6 +5,6 @@ compilerConfig.$inject = ['$compileProvider'];
  */
 export function compilerConfig($compileProvider) {
   $compileProvider.aHrefSanitizationTrustedUrlList(
-      /^\s*(https?|ftp|mailto|tel|file|blob):/
+      /^\s*(https?|ftp|mailto|tel|file|blob):/,
   );
 }

--- a/src/ui/src/js/configs/compiler_config.js
+++ b/src/ui/src/js/configs/compiler_config.js
@@ -1,10 +1,10 @@
-compilerConfig.$inject = ["$compileProvider"];
+compilerConfig.$inject = ['$compileProvider'];
 /**
  * compilerConfig - Angular configuration object for the Angular compiler.
  * @param {$compileProvider} $compileProvider Angular's $compileProvider object.
  */
 export function compilerConfig($compileProvider) {
   $compileProvider.aHrefSanitizationTrustedUrlList(
-    /^\s*(https?|ftp|mailto|tel|file|blob):/
+      /^\s*(https?|ftp|mailto|tel|file|blob):/
   );
 }

--- a/src/ui/src/js/configs/dt_renderer.js
+++ b/src/ui/src/js/configs/dt_renderer.js
@@ -1,4 +1,4 @@
-runDTRenderer.$inject = ["DTRendererService"];
+runDTRenderer.$inject = ['DTRendererService'];
 
 /**
  * runDTRenderer - Tweak datatables rendering
@@ -6,122 +6,122 @@ runDTRenderer.$inject = ["DTRendererService"];
  */
 export default function runDTRenderer(DTRendererService) {
   DTRendererService.registerPlugin({
-    postRender: function (options, result) {
+    postRender: function(options, result) {
       if (options && options.childContainer) {
-        let childContainer = $("<span>")
-          .attr("id", "childContainer")
-          .css("margin-right", "20px")
-          .append(
-            $("<input>")
-              .attr("id", "childCheck")
-              .attr("type", "checkbox")
-              .css("margin-top", "-4px")
-              .change(() => {
-                $(".dataTable").dataTable().fnUpdate();
-              })
-          )
-          .append(
-            $("<label>")
-              .attr("for", "childCheck")
-              .css("padding-left", "4px")
-              .text("Show Children")
-          );
-        $(".dataTables_filter").prepend(childContainer);
+        const childContainer = $('<span>')
+            .attr('id', 'childContainer')
+            .css('margin-right', '20px')
+            .append(
+                $('<input>')
+                    .attr('id', 'childCheck')
+                    .attr('type', 'checkbox')
+                    .css('margin-top', '-4px')
+                    .change(() => {
+                      $('.dataTable').dataTable().fnUpdate();
+                    })
+            )
+            .append(
+                $('<label>')
+                    .attr('for', 'childCheck')
+                    .css('padding-left', '4px')
+                    .text('Show Children')
+            );
+        $('.dataTables_filter').prepend(childContainer);
       }
 
       if (options && options.hiddenRequestContainer) {
-        let hiddenRequestContainer = $("<span>")
-          .attr("id", "hiddenRequestContainer")
-          .css("margin-right", "20px")
-          .append(
-            $("<input>")
-              .attr("id", "hiddenRequestCheck")
-              .attr("type", "checkbox")
-              .css("margin-top", "-4px")
-              .change(() => {
-                $(".dataTable").dataTable().fnUpdate();
-              })
-          )
-          .append(
-            $("<label>")
-              .attr("for", "hiddenRequestCheck")
-              .css("padding-left", "4px")
-              .text("Show Hidden")
-          );
-        $(".dataTables_filter").prepend(hiddenRequestContainer);
+        const hiddenRequestContainer = $('<span>')
+            .attr('id', 'hiddenRequestContainer')
+            .css('margin-right', '20px')
+            .append(
+                $('<input>')
+                    .attr('id', 'hiddenRequestCheck')
+                    .attr('type', 'checkbox')
+                    .css('margin-top', '-4px')
+                    .change(() => {
+                      $('.dataTable').dataTable().fnUpdate();
+                    })
+            )
+            .append(
+                $('<label>')
+                    .attr('for', 'hiddenRequestCheck')
+                    .css('padding-left', '4px')
+                    .text('Show Hidden')
+            );
+        $('.dataTables_filter').prepend(hiddenRequestContainer);
       }
 
       if (options && options.hiddenContainer) {
-        let hiddenContainer = $("<ul>")
-          .attr("id", "hiddenList")
-          .css("margin-right", "20px")
-          .attr(
-            "style",
-            "list-style-type:none;margin-right:20px; display:inline; padding-left:0px;"
-          )
-          .append(
-            $("<label>")
-              .attr("for", "filterHidden")
-              .css("padding-left", "4px")
-              .text("Show Hidden")
-          );
-        $(".dataTables_filter").prepend(hiddenContainer);
-        var node = document.getElementById("filterHidden");
-        var list = document.getElementById("hiddenList");
+        const hiddenContainer = $('<ul>')
+            .attr('id', 'hiddenList')
+            .css('margin-right', '20px')
+            .attr(
+                'style',
+                'list-style-type:none;margin-right:20px; display:inline; padding-left:0px;'
+            )
+            .append(
+                $('<label>')
+                    .attr('for', 'filterHidden')
+                    .css('padding-left', '4px')
+                    .text('Show Hidden')
+            );
+        $('.dataTables_filter').prepend(hiddenContainer);
+        const node = document.getElementById('filterHidden');
+        const list = document.getElementById('hiddenList');
         list.insertBefore(node, list.childNodes[0]);
       }
 
       if (options && options.refreshButton) {
-        let refreshButton = $("<button>")
-          .attr("id", "refreshButton")
-          .attr("type", "button")
-          .addClass("btn")
-          .addClass("btn-default")
-          .addClass("btn-sm")
-          .css("margin-left", "20px")
-          .css("margin-bottom", "5px")
-          .click(() => {
-            $(".dataTable").dataTable().fnUpdate();
-          })
-          .append(
-            $("<span>")
-              .addClass("fa")
-              .addClass("fa-refresh")
-              .css("padding-right", "5px")
-          )
-          .append($("<span>").text("Refresh"));
-        $(".dataTables_length").append(refreshButton);
+        const refreshButton = $('<button>')
+            .attr('id', 'refreshButton')
+            .attr('type', 'button')
+            .addClass('btn')
+            .addClass('btn-default')
+            .addClass('btn-sm')
+            .css('margin-left', '20px')
+            .css('margin-bottom', '5px')
+            .click(() => {
+              $('.dataTable').dataTable().fnUpdate();
+            })
+            .append(
+                $('<span>')
+                    .addClass('fa')
+                    .addClass('fa-refresh')
+                    .css('padding-right', '5px')
+            )
+            .append($('<span>').text('Refresh'));
+        $('.dataTables_length').append(refreshButton);
       }
 
       if (options && options.newData) {
-        let newData = $("<span>")
-          .attr("id", "newData")
-          .css("margin-left", "20px")
-          .css("margin-bottom", "5px")
-          .css("visiblity", "hidden")
-          .append(
-            $("<span>")
-              .addClass("glyphicon")
-              .addClass("glyphicon-info-sign")
-              .css("padding-right", "5px")
-          )
-          .append(
-            $("<span>").css("cursor", "default").text("Updates Detected")
-          );
-        $(".dataTables_length").append(newData);
+        const newData = $('<span>')
+            .attr('id', 'newData')
+            .css('margin-left', '20px')
+            .css('margin-bottom', '5px')
+            .css('visiblity', 'hidden')
+            .append(
+                $('<span>')
+                    .addClass('glyphicon')
+                    .addClass('glyphicon-info-sign')
+                    .css('padding-right', '5px')
+            )
+            .append(
+                $('<span>').css('cursor', 'default').text('Updates Detected')
+            );
+        $('.dataTables_length').append(newData);
       }
 
-      let spinner = $("<span>")
-        .attr("id", "dtSpinner")
-        .addClass("fa fa-spinner fa-pulse fa-lg")
-        .css("margin-right", "20px")
-        .css("margin-left", "20px")
-        .css("visibility", "hidden");
-      $(".dataTables_filter").prepend(spinner);
+      const spinner = $('<span>')
+          .attr('id', 'dtSpinner')
+          .addClass('fa fa-spinner fa-pulse fa-lg')
+          .css('margin-right', '20px')
+          .css('margin-left', '20px')
+          .css('visibility', 'hidden');
+      $('.dataTables_filter').prepend(spinner);
 
       // Register callback to show / hide spinner thingy
       let processingDelay = null;
-      $(".dataTable").on("processing.dt", function (e, settings, processing) {
+      $('.dataTable').on('processing.dt', function(e, settings, processing) {
         // Regardless of whether this event is the start or end of processing
         // we want to clear the current timeout if one exists
         if (processingDelay) {
@@ -129,12 +129,12 @@ export default function runDTRenderer(DTRendererService) {
         }
 
         if (!processing) {
-          $("#dtSpinner").css("visibility", "hidden");
-          $("#refreshButton").prop("disabled", false);
+          $('#dtSpinner').css('visibility', 'hidden');
+          $('#refreshButton').prop('disabled', false);
         } else {
-          processingDelay = setTimeout(function () {
-            $("#dtSpinner").css("visibility", "visible");
-            $("#refreshButton").prop("disabled", true);
+          processingDelay = setTimeout(function() {
+            $('#dtSpinner').css('visibility', 'visible');
+            $('#refreshButton').prop('disabled', true);
           }, 500);
         }
       });

--- a/src/ui/src/js/configs/dt_renderer.js
+++ b/src/ui/src/js/configs/dt_renderer.js
@@ -18,13 +18,13 @@ export default function runDTRenderer(DTRendererService) {
                     .css('margin-top', '-4px')
                     .change(() => {
                       $('.dataTable').dataTable().fnUpdate();
-                    })
+                    }),
             )
             .append(
                 $('<label>')
                     .attr('for', 'childCheck')
                     .css('padding-left', '4px')
-                    .text('Show Children')
+                    .text('Show Children'),
             );
         $('.dataTables_filter').prepend(childContainer);
       }
@@ -40,13 +40,13 @@ export default function runDTRenderer(DTRendererService) {
                     .css('margin-top', '-4px')
                     .change(() => {
                       $('.dataTable').dataTable().fnUpdate();
-                    })
+                    }),
             )
             .append(
                 $('<label>')
                     .attr('for', 'hiddenRequestCheck')
                     .css('padding-left', '4px')
-                    .text('Show Hidden')
+                    .text('Show Hidden'),
             );
         $('.dataTables_filter').prepend(hiddenRequestContainer);
       }
@@ -57,13 +57,13 @@ export default function runDTRenderer(DTRendererService) {
             .css('margin-right', '20px')
             .attr(
                 'style',
-                'list-style-type:none;margin-right:20px; display:inline; padding-left:0px;'
+                'list-style-type:none;margin-right:20px; display:inline; padding-left:0px;',
             )
             .append(
                 $('<label>')
                     .attr('for', 'filterHidden')
                     .css('padding-left', '4px')
-                    .text('Show Hidden')
+                    .text('Show Hidden'),
             );
         $('.dataTables_filter').prepend(hiddenContainer);
         const node = document.getElementById('filterHidden');
@@ -87,7 +87,7 @@ export default function runDTRenderer(DTRendererService) {
                 $('<span>')
                     .addClass('fa')
                     .addClass('fa-refresh')
-                    .css('padding-right', '5px')
+                    .css('padding-right', '5px'),
             )
             .append($('<span>').text('Refresh'));
         $('.dataTables_length').append(refreshButton);
@@ -103,10 +103,10 @@ export default function runDTRenderer(DTRendererService) {
                 $('<span>')
                     .addClass('glyphicon')
                     .addClass('glyphicon-info-sign')
-                    .css('padding-right', '5px')
+                    .css('padding-right', '5px'),
             )
             .append(
-                $('<span>').css('cursor', 'default').text('Updates Detected')
+                $('<span>').css('cursor', 'default').text('Updates Detected'),
             );
         $('.dataTables_length').append(newData);
       }

--- a/src/ui/src/js/configs/http_interceptor.js
+++ b/src/ui/src/js/configs/http_interceptor.js
@@ -1,4 +1,4 @@
-interceptorService.$inject = ["$rootScope", "$templateCache"];
+interceptorService.$inject = ['$rootScope', '$templateCache'];
 /**
  * interceptorService - Used to intercept API requests.
  * @param  {$rootScope} $rootScope         Angular's $rootScope object.
@@ -6,14 +6,14 @@ interceptorService.$inject = ["$rootScope", "$templateCache"];
  */
 export function interceptorService($rootScope, $templateCache) {
   /* eslint-disable no-invalid-this */
-  let service = this;
-  service.request = function (config) {
+  const service = this;
+  service.request = function(config) {
     // Only match things that we know are targeted at our backend
     if (
       $rootScope.apiBaseUrl &&
-      (config.url.startsWith("config") ||
-        config.url.startsWith("version") ||
-        config.url.startsWith("api"))
+      (config.url.startsWith('config') ||
+        config.url.startsWith('version') ||
+        config.url.startsWith('api'))
     ) {
       config.url = $rootScope.apiBaseUrl + config.url;
     }
@@ -22,7 +22,7 @@ export function interceptorService($rootScope, $templateCache) {
   };
 }
 
-authInterceptorService.$inject = ["$q", "$injector"];
+authInterceptorService.$inject = ['$q', '$injector'];
 /**
  * authInterceptorService - Used to intercept API requests.
  * @param  {$q} $q                                   $q object
@@ -37,16 +37,16 @@ export function authInterceptorService($q, $injector) {
       // 401 means 'needs authentication'
       if (rejection.status === 401) {
         // Can't use normal dependency injection in here as it causes a cycle
-        let $http = $injector.get("$http");
-        let $rootScope = $injector.get("$rootScope");
-        let TokenService = $injector.get("TokenService");
+        const $http = $injector.get('$http');
+        const $rootScope = $injector.get('$rootScope');
+        const TokenService = $injector.get('TokenService');
 
-        let deferred = $q.defer();
+        const deferred = $q.defer();
 
         // This attempts to handle the condition where an access token has
         // expired but there's a refresh token in storage. We use the refresh
         // token to get a new access token then re-attempt the original request.
-        let refreshToken = TokenService.getRefresh();
+        const refreshToken = TokenService.getRefresh();
         if (refreshToken) {
           if (!inFlightAuthRequest) {
             inFlightAuthRequest = TokenService.doRefresh(refreshToken);
@@ -61,12 +61,12 @@ export function authInterceptorService($q, $injector) {
 
             // And retry the original request
             $http(rejection.config).then(
-              (response) => {
-                deferred.resolve(response);
-              },
-              (response) => {
-                deferred.reject();
-              }
+                (response) => {
+                  deferred.resolve(response);
+                },
+                (response) => {
+                  deferred.reject();
+                }
             );
           });
 
@@ -76,22 +76,22 @@ export function authInterceptorService($q, $injector) {
           // If this is a GET we're going to assume that retrying is taken care
           // of by the controllers handling the userChange event.
           // For other verbs we'll retry if the login is successful
-          let loginModal = $rootScope.doLogin();
-          if (rejection.config.method !== "GET") {
+          const loginModal = $rootScope.doLogin();
+          if (rejection.config.method !== 'GET') {
             return loginModal.result.then(
-              (result) => {
+                (result) => {
                 // At this point there'll be updated tokens, so set the
                 // Authorization header to the updated default
-                rejection.config.headers.Authorization =
+                  rejection.config.headers.Authorization =
                   $http.defaults.headers.common.Authorization;
 
-                // And then retry the original request
-                return $http(rejection.config);
-              },
-              () => {
+                  // And then retry the original request
+                  return $http(rejection.config);
+                },
+                () => {
                 // User dismissed the modal so return the original rejection
-                return $q.reject(rejection);
-              }
+                  return $q.reject(rejection);
+                }
             );
           }
         }
@@ -104,12 +104,12 @@ export function authInterceptorService($q, $injector) {
   };
 }
 
-interceptorConfig.$inject = ["$httpProvider"];
+interceptorConfig.$inject = ['$httpProvider'];
 /**
  * interceptorConfig - Angular configuration object for API interceptors.
  * @param  {$httpProvider} $httpProvider Angular's $httpProvider object.
  */
 export function interceptorConfig($httpProvider) {
-  $httpProvider.interceptors.push("APIInterceptor");
-  $httpProvider.interceptors.push("authInterceptorService");
+  $httpProvider.interceptors.push('APIInterceptor');
+  $httpProvider.interceptors.push('authInterceptorService');
 }

--- a/src/ui/src/js/configs/http_interceptor.js
+++ b/src/ui/src/js/configs/http_interceptor.js
@@ -66,7 +66,7 @@ export function authInterceptorService($q, $injector) {
                 },
                 (response) => {
                   deferred.reject();
-                }
+                },
             );
           });
 
@@ -91,7 +91,7 @@ export function authInterceptorService($q, $injector) {
                 () => {
                 // User dismissed the modal so return the original rejection
                   return $q.reject(rejection);
-                }
+                },
             );
           }
         }

--- a/src/ui/src/js/configs/routes.js
+++ b/src/ui/src/js/configs/routes.js
@@ -1,10 +1,10 @@
-import { camelCaseKeys } from "../services/utility_service.js";
+import {camelCaseKeys} from '../services/utility_service.js';
 
 routeConfig.$inject = [
-  "$stateProvider",
-  "$urlRouterProvider",
-  "$urlMatcherFactoryProvider",
-  "$locationProvider",
+  '$stateProvider',
+  '$urlRouterProvider',
+  '$urlMatcherFactoryProvider',
+  '$locationProvider',
 ];
 
 /**
@@ -15,241 +15,241 @@ routeConfig.$inject = [
  * @param  {Object} $locationProvider           Angular's $locationProvider object.
  */
 export default function routeConfig(
-  $stateProvider,
-  $urlRouterProvider,
-  $urlMatcherFactoryProvider,
-  $locationProvider
+    $stateProvider,
+    $urlRouterProvider,
+    $urlMatcherFactoryProvider,
+    $locationProvider
 ) {
-  $urlRouterProvider.otherwise("/");
+  $urlRouterProvider.otherwise('/');
   $urlMatcherFactoryProvider.strictMode(false);
 
   // // use the HTML5 History API
   // $locationProvider.html5Mode(true);
 
   $stateProvider
-    .state("base", {
-      url: "/",
-      resolve: {
-        config: [
-          "$rootScope",
-          "UtilityService",
-          ($rootScope, UtilityService) => {
-            return UtilityService.getConfig().then((response) => {
-              angular.extend($rootScope.config, camelCaseKeys(response.data));
-            });
-          },
-        ],
-        namespaces: [
-          "$rootScope",
-          "UtilityService",
-          ($rootScope, UtilityService) => {
-            return UtilityService.getNamespaces().then((response) => {
-              $rootScope.namespaces = response.data;
-            });
-          },
-        ],
-        systems: [
-          "$rootScope",
-          "SystemService",
-          ($rootScope, SystemService) => {
-            return SystemService.getSystems().then(
-              (response) => {
-                $rootScope.sysResponse = response;
-                $rootScope.systems = response.data;
-              },
-              (response) => {
-                $rootScope.sysResponse = response;
-                $rootScope.systems = [];
-              }
-            );
-          },
-        ],
-      },
-    })
-    .state("base.about", {
-      url: "about",
-      templateUrl: "about.html",
-      controller: "AboutController",
-    })
-    .state("login", {
-      templateUrl: "login.html",
-      controller: "LoginController",
-    })
-    .state("base.systems", {
-      url: "systems/",
-      templateUrl: "system_index.html",
-      controller: "SystemIndexController",
-    })
-    .state("base.system", {
-      url: "systems/:namespace/:systemName/:systemVersion",
-      templateUrl: "command_index.html",
-      controller: "CommandIndexController",
-      resolve: {
-        system: [
-          "$stateParams",
-          "SystemService",
-          ($stateParams, SystemService) => {
-            return (
-              SystemService.findSystem(
-                $stateParams.namespace,
-                $stateParams.systemName,
-                $stateParams.systemVersion
-              ) || {}
-            );
-          },
-        ],
-      },
-    })
-    .state("base.systemNs", {
-      url: "systems/:namespace",
-      templateUrl: "command_index.html",
-      controller: "CommandIndexController",
-      resolve: {
-        system: [
-          "$stateParams",
-          "SystemService",
-          ($stateParams, SystemService) => {
-            return SystemService.findSystem($stateParams.namespace) || {};
-          },
-        ],
-      },
-    })
-    .state("base.systemName", {
-      url: "systems/:namespace/:systemName",
-      templateUrl: "command_index.html",
-      controller: "CommandIndexController",
-      resolve: {
-        system: [
-          "$stateParams",
-          "SystemService",
-          ($stateParams, SystemService) => {
-            return (
-              SystemService.findSystem(
-                $stateParams.namespace,
-                $stateParams.systemName
-              ) || {}
-            );
-          },
-        ],
-      },
-    })
-    .state("base.commands", {
-      url: "commands/",
-      templateUrl: "command_index.html",
-      controller: "CommandIndexController",
-    })
-    // Don't ask me why this can't be nested as base.system.command
-    // Think it's something to do with nested views... I think maybe because
-    // base.system defines a template
-    .state("base.command", {
-      url: "systems/:namespace/:systemName/:systemVersion/commands/:commandName/",
-      templateUrl: "command_view.html",
-      controller: "CommandViewController",
-      params: {
-        request: null,
-        id: null,
-      },
-      resolve: {
-        system: [
-          "$stateParams",
-          "SystemService",
-          ($stateParams, SystemService) => {
-            return SystemService.findSystem(
-              $stateParams.namespace,
-              $stateParams.systemName,
-              $stateParams.systemVersion
-            );
-          },
-        ],
-        command: [
-          "$stateParams",
-          "system",
-          ($stateParams, system) => {
-            return _.find(system.commands, { name: $stateParams.commandName });
-          },
-        ],
-      },
-    })
-    .state("base.jobs", {
-      url: "jobs/",
-      templateUrl: "job_index.html",
-      controller: "JobIndexController",
-    })
-    .state("base.jobscreatesystem", {
-      url: "jobs/create/system/",
-      templateUrl: "job/create_system.html",
-      controller: "JobCreateSystemController",
-    })
-    .state("base.jobscreatecommand", {
-      url: "jobs/create/command/",
-      templateUrl: "job/create_command.html",
-      controller: "JobCreateCommandController",
-      params: {
-        system: null,
-      },
-    })
-    .state("base.jobscreaterequest", {
-      url: "jobs/create/request/",
-      templateUrl: "job/create_request.html",
-      controller: "JobCreateRequestController",
-      params: {
-        system: null,
-        command: null,
-        job: null,
-      },
-    })
-    .state("base.jobscreatetrigger", {
-      url: "jobs/create/trigger/",
-      templateUrl: "job/create_trigger.html",
-      controller: "JobCreateTriggerController",
-      params: {
-        request: null,
-        job: null,
-      },
-    })
-    .state("base.job", {
-      url: "jobs/:id/",
-      templateUrl: "job_view.html",
-      controller: "JobViewController",
-    })
-    .state("base.requests", {
-      url: "requests/",
-      templateUrl: "request_index.html",
-      controller: "RequestIndexController",
-    })
-    .state("base.request", {
-      url: "requests/:requestId/",
-      templateUrl: "request_view.html",
-      controller: "RequestViewController",
-    })
-    .state("base.queues", {
-      url: "admin/queues/",
-      templateUrl: "admin_queue.html",
-      controller: "AdminQueueController",
-    })
-    .state("base.system_admin", {
-      url: "admin/systems/",
-      templateUrl: "admin_system.html",
-      controller: "AdminSystemController",
-    })
-    .state("base.garden_admin", {
-      url: "admin/gardens/",
-      templateUrl: "admin_garden_index.html",
-      controller: "AdminGardenController",
-    })
-    .state("base.garden_view", {
-      url: "admin/gardens/:name/",
-      templateUrl: "admin_garden_view.html",
-      controller: "AdminGardenViewController",
-    })
-    .state("base.user_admin", {
-      url: "admin/users/",
-      templateUrl: "admin_user.html",
-      controller: "AdminUserController",
-    })
-    .state("base.role_admin", {
-      url: "admin/roles/",
-      templateUrl: "admin_role.html",
-      controller: "AdminRoleController",
-    });
+      .state('base', {
+        url: '/',
+        resolve: {
+          config: [
+            '$rootScope',
+            'UtilityService',
+            ($rootScope, UtilityService) => {
+              return UtilityService.getConfig().then((response) => {
+                angular.extend($rootScope.config, camelCaseKeys(response.data));
+              });
+            },
+          ],
+          namespaces: [
+            '$rootScope',
+            'UtilityService',
+            ($rootScope, UtilityService) => {
+              return UtilityService.getNamespaces().then((response) => {
+                $rootScope.namespaces = response.data;
+              });
+            },
+          ],
+          systems: [
+            '$rootScope',
+            'SystemService',
+            ($rootScope, SystemService) => {
+              return SystemService.getSystems().then(
+                  (response) => {
+                    $rootScope.sysResponse = response;
+                    $rootScope.systems = response.data;
+                  },
+                  (response) => {
+                    $rootScope.sysResponse = response;
+                    $rootScope.systems = [];
+                  }
+              );
+            },
+          ],
+        },
+      })
+      .state('base.about', {
+        url: 'about',
+        templateUrl: 'about.html',
+        controller: 'AboutController',
+      })
+      .state('login', {
+        templateUrl: 'login.html',
+        controller: 'LoginController',
+      })
+      .state('base.systems', {
+        url: 'systems/',
+        templateUrl: 'system_index.html',
+        controller: 'SystemIndexController',
+      })
+      .state('base.system', {
+        url: 'systems/:namespace/:systemName/:systemVersion',
+        templateUrl: 'command_index.html',
+        controller: 'CommandIndexController',
+        resolve: {
+          system: [
+            '$stateParams',
+            'SystemService',
+            ($stateParams, SystemService) => {
+              return (
+                SystemService.findSystem(
+                    $stateParams.namespace,
+                    $stateParams.systemName,
+                    $stateParams.systemVersion
+                ) || {}
+              );
+            },
+          ],
+        },
+      })
+      .state('base.systemNs', {
+        url: 'systems/:namespace',
+        templateUrl: 'command_index.html',
+        controller: 'CommandIndexController',
+        resolve: {
+          system: [
+            '$stateParams',
+            'SystemService',
+            ($stateParams, SystemService) => {
+              return SystemService.findSystem($stateParams.namespace) || {};
+            },
+          ],
+        },
+      })
+      .state('base.systemName', {
+        url: 'systems/:namespace/:systemName',
+        templateUrl: 'command_index.html',
+        controller: 'CommandIndexController',
+        resolve: {
+          system: [
+            '$stateParams',
+            'SystemService',
+            ($stateParams, SystemService) => {
+              return (
+                SystemService.findSystem(
+                    $stateParams.namespace,
+                    $stateParams.systemName
+                ) || {}
+              );
+            },
+          ],
+        },
+      })
+      .state('base.commands', {
+        url: 'commands/',
+        templateUrl: 'command_index.html',
+        controller: 'CommandIndexController',
+      })
+  // Don't ask me why this can't be nested as base.system.command
+  // Think it's something to do with nested views... I think maybe because
+  // base.system defines a template
+      .state('base.command', {
+        url: 'systems/:namespace/:systemName/:systemVersion/commands/:commandName/',
+        templateUrl: 'command_view.html',
+        controller: 'CommandViewController',
+        params: {
+          request: null,
+          id: null,
+        },
+        resolve: {
+          system: [
+            '$stateParams',
+            'SystemService',
+            ($stateParams, SystemService) => {
+              return SystemService.findSystem(
+                  $stateParams.namespace,
+                  $stateParams.systemName,
+                  $stateParams.systemVersion
+              );
+            },
+          ],
+          command: [
+            '$stateParams',
+            'system',
+            ($stateParams, system) => {
+              return _.find(system.commands, {name: $stateParams.commandName});
+            },
+          ],
+        },
+      })
+      .state('base.jobs', {
+        url: 'jobs/',
+        templateUrl: 'job_index.html',
+        controller: 'JobIndexController',
+      })
+      .state('base.jobscreatesystem', {
+        url: 'jobs/create/system/',
+        templateUrl: 'job/create_system.html',
+        controller: 'JobCreateSystemController',
+      })
+      .state('base.jobscreatecommand', {
+        url: 'jobs/create/command/',
+        templateUrl: 'job/create_command.html',
+        controller: 'JobCreateCommandController',
+        params: {
+          system: null,
+        },
+      })
+      .state('base.jobscreaterequest', {
+        url: 'jobs/create/request/',
+        templateUrl: 'job/create_request.html',
+        controller: 'JobCreateRequestController',
+        params: {
+          system: null,
+          command: null,
+          job: null,
+        },
+      })
+      .state('base.jobscreatetrigger', {
+        url: 'jobs/create/trigger/',
+        templateUrl: 'job/create_trigger.html',
+        controller: 'JobCreateTriggerController',
+        params: {
+          request: null,
+          job: null,
+        },
+      })
+      .state('base.job', {
+        url: 'jobs/:id/',
+        templateUrl: 'job_view.html',
+        controller: 'JobViewController',
+      })
+      .state('base.requests', {
+        url: 'requests/',
+        templateUrl: 'request_index.html',
+        controller: 'RequestIndexController',
+      })
+      .state('base.request', {
+        url: 'requests/:requestId/',
+        templateUrl: 'request_view.html',
+        controller: 'RequestViewController',
+      })
+      .state('base.queues', {
+        url: 'admin/queues/',
+        templateUrl: 'admin_queue.html',
+        controller: 'AdminQueueController',
+      })
+      .state('base.system_admin', {
+        url: 'admin/systems/',
+        templateUrl: 'admin_system.html',
+        controller: 'AdminSystemController',
+      })
+      .state('base.garden_admin', {
+        url: 'admin/gardens/',
+        templateUrl: 'admin_garden_index.html',
+        controller: 'AdminGardenController',
+      })
+      .state('base.garden_view', {
+        url: 'admin/gardens/:name/',
+        templateUrl: 'admin_garden_view.html',
+        controller: 'AdminGardenViewController',
+      })
+      .state('base.user_admin', {
+        url: 'admin/users/',
+        templateUrl: 'admin_user.html',
+        controller: 'AdminUserController',
+      })
+      .state('base.role_admin', {
+        url: 'admin/roles/',
+        templateUrl: 'admin_role.html',
+        controller: 'AdminRoleController',
+      });
 }

--- a/src/ui/src/js/configs/routes.js
+++ b/src/ui/src/js/configs/routes.js
@@ -18,7 +18,7 @@ export default function routeConfig(
     $stateProvider,
     $urlRouterProvider,
     $urlMatcherFactoryProvider,
-    $locationProvider
+    $locationProvider,
 ) {
   $urlRouterProvider.otherwise('/');
   $urlMatcherFactoryProvider.strictMode(false);
@@ -60,7 +60,7 @@ export default function routeConfig(
                   (response) => {
                     $rootScope.sysResponse = response;
                     $rootScope.systems = [];
-                  }
+                  },
               );
             },
           ],
@@ -93,7 +93,7 @@ export default function routeConfig(
                 SystemService.findSystem(
                     $stateParams.namespace,
                     $stateParams.systemName,
-                    $stateParams.systemVersion
+                    $stateParams.systemVersion,
                 ) || {}
               );
             },
@@ -126,7 +126,7 @@ export default function routeConfig(
               return (
                 SystemService.findSystem(
                     $stateParams.namespace,
-                    $stateParams.systemName
+                    $stateParams.systemName,
                 ) || {}
               );
             },
@@ -157,7 +157,7 @@ export default function routeConfig(
               return SystemService.findSystem(
                   $stateParams.namespace,
                   $stateParams.systemName,
-                  $stateParams.systemVersion
+                  $stateParams.systemVersion,
               );
             },
           ],

--- a/src/ui/src/js/controllers/about.js
+++ b/src/ui/src/js/controllers/about.js
@@ -15,6 +15,6 @@ export default function AboutController($scope, UtilityService) {
       },
       (response) => {
         $scope.response = response;
-      }
+      },
   );
 }

--- a/src/ui/src/js/controllers/about.js
+++ b/src/ui/src/js/controllers/about.js
@@ -1,4 +1,4 @@
-AboutController.$inject = ["$scope", "UtilityService"];
+AboutController.$inject = ['$scope', 'UtilityService'];
 
 /**
  * AboutController - Angular controller for the about page.
@@ -6,15 +6,15 @@ AboutController.$inject = ["$scope", "UtilityService"];
  * @param  {Object} UtilityService Beer-Garden's utility service object.
  */
 export default function AboutController($scope, UtilityService) {
-  $scope.setWindowTitle("about");
+  $scope.setWindowTitle('about');
 
   UtilityService.getVersion().then(
-    (response) => {
-      $scope.response = response;
-      $scope.data = response.data;
-    },
-    (response) => {
-      $scope.response = response;
-    }
+      (response) => {
+        $scope.response = response;
+        $scope.data = response.data;
+      },
+      (response) => {
+        $scope.response = response;
+      }
   );
 }

--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -19,7 +19,7 @@ export default function adminGardenController(
     $scope,
     $state,
     GardenService,
-    EventService
+    EventService,
 ) {
   $scope.setWindowTitle('gardens');
   $scope.gardenCreateSchema = GardenService.CreateSCHEMA;
@@ -43,7 +43,7 @@ export default function adminGardenController(
   const loadGardens = function() {
     GardenService.getGardens().then(
         $scope.successCallback,
-        $scope.failureCallback
+        $scope.failureCallback,
     );
   };
 

--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -1,10 +1,11 @@
-import _ from "lodash";
+// eslint-disable-next-line no-unused-vars
+import _ from 'lodash';
 
 adminGardenController.$inject = [
-  "$scope",
-  "$state",
-  "GardenService",
-  "EventService",
+  '$scope',
+  '$state',
+  'GardenService',
+  'EventService',
 ];
 
 /**
@@ -15,15 +16,15 @@ adminGardenController.$inject = [
  */
 
 export default function adminGardenController(
-  $scope,
-  $state,
-  GardenService,
-  EventService
+    $scope,
+    $state,
+    GardenService,
+    EventService
 ) {
-  $scope.setWindowTitle("gardens");
+  $scope.setWindowTitle('gardens');
   $scope.gardenCreateSchema = GardenService.CreateSCHEMA;
   $scope.gardenCreateForm = GardenService.CreateFORM;
-  $scope.successCallback = function (response) {
+  $scope.successCallback = function(response) {
     $scope.response = response;
     $scope.data = response.data;
   };
@@ -31,7 +32,7 @@ export default function adminGardenController(
   $scope.createGardenFormHide = true;
   $scope.create_garden_name = null;
   $scope.createGardenFormHide = true;
-  $scope.failureCallback = function (response) {
+  $scope.failureCallback = function(response) {
     $scope.response = response;
     $scope.data = [];
   };
@@ -39,78 +40,78 @@ export default function adminGardenController(
   $scope.create_garden_popover_message = null;
   $scope.create_garden_name_focus = false;
 
-  let loadGardens = function () {
+  const loadGardens = function() {
     GardenService.getGardens().then(
-      $scope.successCallback,
-      $scope.failureCallback
+        $scope.successCallback,
+        $scope.failureCallback
     );
   };
 
-  $scope.syncGardens = function () {
+  $scope.syncGardens = function() {
     GardenService.syncGardens();
   };
 
-  $scope.closeCreateGardenForm = function () {
+  $scope.closeCreateGardenForm = function() {
     $scope.createGardenFormHide = true;
     $scope.create_garden_name = null;
   };
 
-  $scope.checkForGardenDuplication = function () {
+  $scope.checkForGardenDuplication = function() {
     $scope.is_unique_garden_name = true;
     $scope.create_garden_popover_message = null;
     $scope.create_garden_popover_active = false;
     for (let i = 0; i < $scope.data.length; i++) {
       if ($scope.data[i].name == $scope.create_garden_name) {
         $scope.is_unique_garden_name = false;
-        $scope.create_garden_popover_message = "Garden name is already in use.";
+        $scope.create_garden_popover_message = 'Garden name is already in use.';
         break;
       }
     }
   };
 
-  $scope.createGarden = function () {
+  $scope.createGarden = function() {
     if ($scope.is_unique_garden_name) {
       GardenService.createGarden({
         name: $scope.create_garden_name,
-        status: "NOT_CONFIGURED",
+        status: 'NOT_CONFIGURED',
       });
-      $state.go("base.garden_view", {
+      $state.go('base.garden_view', {
         name: $scope.create_garden_name,
       });
     }
   };
 
-  $scope.editGarden = function (garden) {
-    $state.go("base.garden_view", {
+  $scope.editGarden = function(garden) {
+    $state.go('base.garden_view', {
       name: garden.name,
     });
   };
 
-  $scope.deleteGarden = function (garden) {
+  $scope.deleteGarden = function(garden) {
     GardenService.deleteGarden(garden);
   };
 
-  let loadAll = function () {
+  const loadAll = function() {
     $scope.response = undefined;
     $scope.data = [];
 
     loadGardens();
   };
 
-  EventService.addCallback("admin_garden", (event) => {
+  EventService.addCallback('admin_garden', (event) => {
     switch (event.name) {
-      case "GARDEN_CREATED":
+      case 'GARDEN_CREATED':
         $scope.data.push(event.payload);
         break;
-      case "GARDEN_REMOVED":
-        for (var i = 0; i < $scope.data.length; i++) {
+      case 'GARDEN_REMOVED':
+        for (let i = 0; i < $scope.data.length; i++) {
           if ($scope.data[i].id == event.payload.id) {
             $scope.data.splice(i, 1);
           }
         }
         break;
-      case "GARDEN_UPDATED":
-        for (var i = 0; i < $scope.data.length; i++) {
+      case 'GARDEN_UPDATED':
+        for (let i = 0; i < $scope.data.length; i++) {
           if ($scope.data[i].id == event.payload.id) {
             $scope.data[i] = event.payload;
           }
@@ -119,11 +120,11 @@ export default function adminGardenController(
     }
   });
 
-  $scope.$on("$destroy", function () {
-    EventService.removeCallback("admin_garden");
+  $scope.$on('$destroy', function() {
+    EventService.removeCallback('admin_garden');
   });
 
-  $scope.$on("userChange", function () {
+  $scope.$on('userChange', function() {
     loadAll();
   });
 

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -1,24 +1,26 @@
-import _ from "lodash";
+import _ from 'lodash';
 
 adminGardenViewController.$inject = [
-  "$scope",
-  "GardenService",
-  "EventService",
-  "$stateParams",
+  '$scope',
+  'GardenService',
+  'EventService',
+  '$stateParams',
 ];
 
 /**
  * adminGardenController - Garden management controller.
  * @param  {Object} $scope          Angular's $scope object.
  * @param  {Object} GardenService    Beer-Garden's garden service object.
+ * @param   {Object} EventService    Beer-Garden's event service object.
+ * @param   {$stateParams} $stateParams State params
  */
 export default function adminGardenViewController(
-  $scope,
-  GardenService,
-  EventService,
-  $stateParams
+    $scope,
+    GardenService,
+    EventService,
+    $stateParams
 ) {
-  $scope.setWindowTitle("Configure Garden");
+  $scope.setWindowTitle('Configure Garden');
   $scope.alerts = [];
 
   $scope.isLocal = false;
@@ -26,85 +28,85 @@ export default function adminGardenViewController(
   $scope.gardenForm = null;
   $scope.gardenModel = {};
 
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
-  let generateGardenSF = function () {
+  const generateGardenSF = function() {
     $scope.gardenSchema = GardenService.SCHEMA;
     $scope.gardenForm = GardenService.FORM;
     $scope.gardenModel = GardenService.serverModelToForm($scope.data);
 
-    $scope.$broadcast("schemaFormRedraw");
+    $scope.$broadcast('schemaFormRedraw');
   };
 
-  $scope.successCallback = function (response) {
+  $scope.successCallback = function(response) {
     $scope.response = response;
     $scope.data = response.data;
 
-    if ($scope.data.id == null || $scope.data.connection_type == "LOCAL") {
+    if ($scope.data.id == null || $scope.data.connection_type == 'LOCAL') {
       $scope.isLocal = true;
       $scope.alerts.push({
-        type: "info",
-        msg: "Since this is the local Garden it's not possible to modify connection information",
+        type: 'info',
+        msg: 'Since this is the local Garden it\'s not possible to modify connection information',
       });
     }
 
     generateGardenSF();
   };
 
-  $scope.failureCallback = function (response) {
+  $scope.failureCallback = function(response) {
     $scope.response = response;
     $scope.data = [];
   };
 
-  let loadGarden = function () {
+  const loadGarden = function() {
     GardenService.getGarden($stateParams.name).then(
-      $scope.successCallback,
-      $scope.failureCallback
+        $scope.successCallback,
+        $scope.failureCallback
     );
   };
 
-  let loadAll = function () {
+  const loadAll = function() {
     $scope.response = undefined;
     $scope.data = [];
 
     loadGarden();
   };
 
-  $scope.addErrorAlert = function (response) {
+  $scope.addErrorAlert = function(response) {
     $scope.alerts.push({
-      type: "danger",
+      type: 'danger',
       msg:
-        "Something went wrong on the backend: " +
-        _.get(response, "data.message", "Please check the server logs"),
+        'Something went wrong on the backend: ' +
+        _.get(response, 'data.message', 'Please check the server logs'),
     });
   };
 
-  $scope.submitGardenForm = function (form, model) {
-    $scope.$broadcast("schemaFormValidate");
+  $scope.submitGardenForm = function(form, model) {
+    $scope.$broadcast('schemaFormValidate');
 
     if (form.$valid) {
-      let updated_garden = GardenService.formToServerModel($scope.data, model);
+      const updatedGarden = GardenService.formToServerModel($scope.data, model);
 
-      GardenService.updateGardenConfig(updated_garden).then(
-        _.noop,
-        $scope.addErrorAlert
+      GardenService.updateGardenConfig(updatedGarden).then(
+          _.noop,
+          $scope.addErrorAlert
       );
     } else {
       $scope.alerts.push(
-        "Looks like there was an error validating the Garden."
+          'Looks like there was an error validating the Garden.'
       );
     }
   };
 
-  $scope.syncGarden = function () {
+  $scope.syncGarden = function() {
     GardenService.syncGarden($scope.data.name);
   };
 
-  EventService.addCallback("admin_garden_view", (event) => {
+  EventService.addCallback('admin_garden_view', (event) => {
     switch (event.name) {
-      case "GARDEN_UPDATED":
+      case 'GARDEN_UPDATED':
         if ($scope.data.id == event.payload.id) {
           $scope.data = event.payload;
         }
@@ -112,11 +114,11 @@ export default function adminGardenViewController(
     }
   });
 
-  $scope.$on("$destroy", function () {
-    EventService.removeCallback("admin_garden_view");
+  $scope.$on('$destroy', function() {
+    EventService.removeCallback('admin_garden_view');
   });
 
-  $scope.$on("userChange", function () {
+  $scope.$on('userChange', function() {
     loadAll();
   });
 

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line no-unused-vars
+import angular from 'angular';
 import _ from 'lodash';
 
 adminGardenViewController.$inject = [
@@ -9,19 +11,20 @@ adminGardenViewController.$inject = [
 
 /**
  * adminGardenController - Garden management controller.
- * @param  {Object} $scope          Angular's $scope object.
- * @param  {Object} GardenService    Beer-Garden's garden service object.
- * @param   {Object} EventService    Beer-Garden's event service object.
- * @param   {$stateParams} $stateParams State params
+ * @param  {Object} $scope              Angular's $scope object.
+ * @param  {Object} GardenService       Beer-Garden's garden service object.
+ * @param  {Object} EventService        Beer-Garden's event service object.
+ * @param  {$stateParams} $stateParams  Router state params
  */
 export default function adminGardenViewController(
     $scope,
     GardenService,
     EventService,
-    $stateParams
+    $stateParams,
 ) {
   $scope.setWindowTitle('Configure Garden');
   $scope.alerts = [];
+  $scope.formErrors = [];
 
   $scope.isLocal = false;
   $scope.gardenSchema = null;
@@ -41,6 +44,7 @@ export default function adminGardenViewController(
   };
 
   $scope.successCallback = function(response) {
+    console.log('response', response);
     $scope.response = response;
     $scope.data = response.data;
 
@@ -48,7 +52,8 @@ export default function adminGardenViewController(
       $scope.isLocal = true;
       $scope.alerts.push({
         type: 'info',
-        msg: 'Since this is the local Garden it\'s not possible to modify connection information',
+        msg: 'Since this is the local Garden it\'s not possible to modify ' +
+        'connection information',
       });
     }
 
@@ -63,7 +68,7 @@ export default function adminGardenViewController(
   const loadGarden = function() {
     GardenService.getGarden($stateParams.name).then(
         $scope.successCallback,
-        $scope.failureCallback
+        $scope.failureCallback,
     );
   };
 
@@ -74,28 +79,125 @@ export default function adminGardenViewController(
     loadGarden();
   };
 
+  const errorPlaceholder = 'errorPlaceholder';
+
+  const resetAllValidationErrors = () => {
+    const updater = (field) => {
+      $scope.$broadcast(
+          `schemaForm.error.${field}`,
+          errorPlaceholder,
+          true,
+      );
+    };
+
+    // this is brittle because it's a copy/paste from the form code,
+    // but will suffice for now because we expect the form won't
+    // ever be updated in this version of the UI
+    const httpFlds = [
+      'http.host',
+      'http.port',
+      'http.url_prefix',
+      'http.ssl',
+      'http.ca_cert',
+      'http.ca_verify',
+      'http.client_cert',
+    ];
+    const stompFlds = [
+      'stomp.host',
+      'stomp.port',
+      'stomp.send_destination',
+      'stomp.subscribe_destination',
+      'stomp.username',
+      'stomp.password',
+      'stomp.ssl',
+      'stomp.headers',
+    ];
+
+    httpFlds.map(updater);
+    stompFlds.map(updater);
+  };
+
+  const fieldErrorName =
+    (entryPoint, fieldName) => `schemaForm.error.${entryPoint}.${fieldName}`;
+
+  const fieldErrorMessage =
+    (errorObject) =>
+      typeof errorObject === 'string' ? Array(errorObject) : errorObject;
+
+  const updateValidationMessages = (entryPoint, errorsObject) => {
+    for (const fieldName in errorsObject) {
+      if (errorsObject.hasOwnProperty(fieldName)) {
+        $scope.$broadcast(
+            fieldErrorName(entryPoint, fieldName),
+            errorPlaceholder,
+            fieldErrorMessage(errorsObject[fieldName]),
+        );
+      }
+    }
+  };
+
   $scope.addErrorAlert = function(response) {
-    $scope.alerts.push({
-      type: 'danger',
-      msg:
-        'Something went wrong on the backend: ' +
-        _.get(response, 'data.message', 'Please check the server logs'),
-    });
+    /* If we have an error response that indicates that the connection
+     * parameters are incorrect, display a warning alert specifying which of the
+     * entry points are wrong. Then update the validation of the individual
+     * schema fields.
+     */
+    if (response['data'] && response['data']['message']) {
+      const messageData = String(response['data']['message']);
+      console.log('MESSG', messageData, 'TYPE', typeof messageData);
+      const cleanedMessages = messageData.replace(/'/g, '"');
+      const messages = JSON.parse(cleanedMessages);
+
+      if ('connection_params' in messages) {
+        const connParamErrors = messages['connection_params'];
+
+        for (const entryPoint in connParamErrors) {
+          if (connParamErrors.hasOwnProperty(entryPoint)) {
+            updateValidationMessages(entryPoint, connParamErrors[entryPoint]);
+
+            $scope.alerts.push({
+              type: 'warning',
+              msg: `Errors found in ${entryPoint} connection`,
+            });
+          }
+        }
+      }
+    } else {
+      $scope.alerts.push({
+        type: 'danger',
+        msg: 'Something went wrong on the backend: ' +
+          _.get(response, 'data.message', 'Please check the server logs'),
+      });
+    }
   };
 
   $scope.submitGardenForm = function(form, model) {
+    $scope.alerts = [];
+    resetAllValidationErrors();
     $scope.$broadcast('schemaFormValidate');
 
     if (form.$valid) {
-      const updatedGarden = GardenService.formToServerModel($scope.data, model);
+      let updatedGarden = undefined;
 
-      GardenService.updateGardenConfig(updatedGarden).then(
-          _.noop,
-          $scope.addErrorAlert
-      );
+      try {
+        updatedGarden =
+          GardenService.formToServerModel($scope.data, model);
+      } catch (e) {
+        $scope.alerts.push({
+          type: 'warning',
+          msg: e,
+        });
+      }
+
+      if (updatedGarden) {
+        GardenService.updateGardenConfig(updatedGarden).then(
+            _.noop,
+            $scope.addErrorAlert,
+        );
+      }
     } else {
       $scope.alerts.push(
-          'Looks like there was an error validating the Garden.'
+          'There was an error validating the Garden.',
       );
     }
   };

--- a/src/ui/src/js/controllers/admin_queue.js
+++ b/src/ui/src/js/controllers/admin_queue.js
@@ -1,79 +1,76 @@
-import angular from "angular";
+import angular from 'angular';
 
 adminQueueController.$inject = [
-  "$scope",
-  "$uibModalInstance",
-  "$interval",
-  "QueueService",
-  "system",
-  "instance",
+  '$scope',
+  '$uibModalInstance',
+  '$interval',
+  'QueueService',
+  'system',
+  'instance',
 ];
 
 /**
  * adminQueueController - Angular controller for queue index page.
- * @param  {Object} $rootScope        Angular's $rootScope object.
  * @param  {Object} $scope            Angular's $scope object.
- * @param  {Object} $q                Angular's $q object.
- * @param  {Object} $compile          Angular's $compile object.
+ * @param  {Object} $uibModalInstance Modal instance
  * @param  {Object} $interval         Angular's $interval object.
- * @param  {Object} DTOptionsBuilder  Datatables' options builder object.
- * @param  {Object} DTColumnBuilder   Datatables' column builder object.
- * @param  {Object} SystemService     Beer-Garden's system service object.
  * @param  {Object} QueueService      Beer-Garden's queue service object.
+ * @param  {Object} system            System
+ * @param  {Object} instance          Instance
  */
 export default function adminQueueController(
-  $scope,
-  $uibModalInstance,
-  $interval,
-  QueueService,
-  system,
-  instance
+    $scope,
+    $uibModalInstance,
+    $interval,
+    QueueService,
+    system,
+    instance
 ) {
   $scope.alerts = [];
   $scope.system = system;
   $scope.instance = instance;
   $scope.queues = [];
 
-  $scope.clearQueue = function (queueName) {
+  $scope.clearQueue = function(queueName) {
     QueueService.clearQueue(queueName).then(
-      $scope.addSuccessAlert,
-      $scope.failureCallback
+        $scope.addSuccessAlert,
+        $scope.failureCallback
     );
   };
 
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
-  $scope.addSuccessAlert = function (response) {
+  $scope.addSuccessAlert = function(response) {
     $scope.alerts.push({
-      type: "success",
-      msg: "Success! Please allow 10 seconds for the message counts to update.",
+      type: 'success',
+      msg: 'Success! Please allow 10 seconds for the message counts to update.',
     });
   };
 
-  $scope.addErrorAlert = function (response) {
-    let msg = "Uh oh! It looks like there was a problem clearing the queue.\n";
+  $scope.addErrorAlert = function(response) {
+    let msg = 'Uh oh! It looks like there was a problem clearing the queue.\n';
     if (response.data !== undefined && response.data !== null) {
       msg += response.data;
     }
     $scope.alerts.push({
-      type: "danger",
+      type: 'danger',
       msg: msg,
     });
   };
 
-  $scope.successCallback = function (response) {
+  $scope.successCallback = function(response) {
     $scope.response = response;
     $scope.queues = response.data;
     return response.data;
   };
 
-  $scope.failureCallback = function (response) {
+  $scope.failureCallback = function(response) {
     $scope.response = response;
   };
 
-  $scope.closeDialog = function () {
+  $scope.closeDialog = function() {
     if (angular.isDefined(poller)) {
       $interval.cancel(poller);
       poller = undefined;
@@ -82,11 +79,11 @@ export default function adminQueueController(
     $uibModalInstance.close();
   };
 
-  let poller = $interval(function () {
+  let poller = $interval(function() {
     loadQueues();
   }, 10000);
 
-  $scope.$on("$destroy", function () {
+  $scope.$on('$destroy', function() {
     if (angular.isDefined(poller)) {
       $inteval.cancel(poller);
       poller = undefined;
@@ -97,8 +94,8 @@ export default function adminQueueController(
     $scope.response = undefined;
 
     $scope.queues = QueueService.getInstanceQueues($scope.instance.id).then(
-      $scope.successCallback,
-      $scope.addErrorAlert
+        $scope.successCallback,
+        $scope.addErrorAlert
     );
   }
 

--- a/src/ui/src/js/controllers/admin_queue.js
+++ b/src/ui/src/js/controllers/admin_queue.js
@@ -24,7 +24,7 @@ export default function adminQueueController(
     $interval,
     QueueService,
     system,
-    instance
+    instance,
 ) {
   $scope.alerts = [];
   $scope.system = system;
@@ -34,7 +34,7 @@ export default function adminQueueController(
   $scope.clearQueue = function(queueName) {
     QueueService.clearQueue(queueName).then(
         $scope.addSuccessAlert,
-        $scope.failureCallback
+        $scope.failureCallback,
     );
   };
 
@@ -95,7 +95,7 @@ export default function adminQueueController(
 
     $scope.queues = QueueService.getInstanceQueues($scope.instance.id).then(
         $scope.successCallback,
-        $scope.addErrorAlert
+        $scope.addErrorAlert,
     );
   }
 

--- a/src/ui/src/js/controllers/admin_role.js
+++ b/src/ui/src/js/controllers/admin_role.js
@@ -1,14 +1,14 @@
-import _ from "lodash";
-import { arrayToMap, mapToArray } from "../services/utility_service.js";
+import _ from 'lodash';
+import {arrayToMap, mapToArray} from '../services/utility_service.js';
 
-import template from "../../templates/new_role.html";
+import template from '../../templates/new_role.html';
 
 adminRoleController.$inject = [
-  "$scope",
-  "$q",
-  "$uibModal",
-  "RoleService",
-  "PermissionService",
+  '$scope',
+  '$q',
+  '$uibModal',
+  'RoleService',
+  'PermissionService',
 ];
 
 /**
@@ -20,13 +20,13 @@ adminRoleController.$inject = [
  * @param  {Object} PermissionService Beer-Garden's permission service object.
  */
 export function adminRoleController(
-  $scope,
-  $q,
-  $uibModal,
-  RoleService,
-  PermissionService
+    $scope,
+    $q,
+    $uibModal,
+    RoleService,
+    PermissionService
 ) {
-  $scope.setWindowTitle("roles");
+  $scope.setWindowTitle('roles');
 
   // This holds the raw responses from the backend
   $scope.raws = {};
@@ -43,45 +43,45 @@ export function adminRoleController(
   // Normal loader
   $scope.loader = {};
 
-  $scope.doCreate = function () {
-    let modalInstance = $uibModal.open({
-      controller: "NewRoleController",
-      size: "sm",
+  $scope.doCreate = function() {
+    const modalInstance = $uibModal.open({
+      controller: 'NewRoleController',
+      size: 'sm',
       template: template,
     });
 
     modalInstance.result.then(
-      (create) => {
-        RoleService.createRole(create).then(loadAll);
-      },
-      // We don't really need to do anything if canceled
-      () => {}
+        (create) => {
+          RoleService.createRole(create).then(loadAll);
+        },
+        // We don't really need to do anything if canceled
+        () => {}
     );
   };
 
-  $scope.doDelete = function (roleId) {
+  $scope.doDelete = function(roleId) {
     RoleService.deleteRole(roleId).then(loadAll);
   };
 
-  $scope.doReset = function (roleId) {
-    let original = _.find($scope.serverRoles, { id: roleId });
-    let changed = _.find($scope.roles, { id: roleId });
+  $scope.doReset = function(roleId) {
+    const original = _.find($scope.serverRoles, {id: roleId});
+    const changed = _.find($scope.roles, {id: roleId});
 
     changed.roles = _.cloneDeep(original.roles);
     changed.permissions = _.cloneDeep(original.permissions);
   };
 
-  $scope.doUpdate = function () {
-    let roleId = $scope.selectedRole.id;
-    let original = _.find($scope.serverRoles, { id: roleId });
-    let promises = [];
+  $scope.doUpdate = function() {
+    const roleId = $scope.selectedRole.id;
+    const original = _.find($scope.serverRoles, {id: roleId});
+    const promises = [];
 
     if ($scope.selectedRole.rolesChanged) {
-      let originalList = mapToArray(original.primaryRoles);
-      let changedList = mapToArray($scope.selectedRole.primaryRoles);
+      const originalList = mapToArray(original.primaryRoles);
+      const changedList = mapToArray($scope.selectedRole.primaryRoles);
 
-      let additions = _.difference(changedList, originalList);
-      let removals = _.difference(originalList, changedList);
+      const additions = _.difference(changedList, originalList);
+      const removals = _.difference(originalList, changedList);
 
       if (additions.length) {
         promises.push(RoleService.addRoles(roleId, additions));
@@ -90,11 +90,11 @@ export function adminRoleController(
         promises.push(RoleService.removeRoles(roleId, removals));
       }
     } else if ($scope.selectedRole.permissionsChanged) {
-      let originalList = mapToArray(original.permissions);
-      let changedList = mapToArray($scope.selectedRole.permissions);
+      const originalList = mapToArray(original.permissions);
+      const changedList = mapToArray($scope.selectedRole.permissions);
 
-      let additions = _.difference(changedList, originalList);
-      let removals = _.difference(originalList, changedList);
+      const additions = _.difference(changedList, originalList);
+      const removals = _.difference(originalList, changedList);
 
       if (additions.length) {
         promises.push(RoleService.addPermissions(roleId, additions));
@@ -107,38 +107,38 @@ export function adminRoleController(
     $q.all(promises).then(loadAll, $scope.addErrorAlert);
   };
 
-  $scope.addErrorAlert = function (response) {
+  $scope.addErrorAlert = function(response) {
     $scope.alerts.push({
-      type: "danger",
+      type: 'danger',
       msg:
-        "Something went wrong on the backend: " +
-        _.get(response, "data.message", "Please check the server logs"),
+        'Something went wrong on the backend: ' +
+        _.get(response, 'data.message', 'Please check the server logs'),
     });
   };
 
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
-  $scope.color = function (roleId, path) {
+  $scope.color = function(roleId, path) {
     // Pull the correct users based on the current selected user's id
-    let originalSelected = _.find($scope.serverRoles, { id: roleId });
-    let changedSelected = _.find($scope.roles, { id: roleId });
+    const originalSelected = _.find($scope.serverRoles, {id: roleId});
+    const changedSelected = _.find($scope.roles, {id: roleId});
 
     // Now pull the original and changed values out
-    let originalValue = _.get(originalSelected, path);
-    let changedValue = _.get(changedSelected, path);
+    const originalValue = _.get(originalSelected, path);
+    const changedValue = _.get(changedSelected, path);
 
     if (changedValue && !originalValue) {
-      return { color: "green" };
+      return {color: 'green'};
     } else if (!changedValue && originalValue) {
-      return { color: "red" };
+      return {color: 'red'};
     }
 
     return {};
   };
 
-  $scope.isRoleDisabled = function (nestedRoleName) {
+  $scope.isRoleDisabled = function(nestedRoleName) {
     // Roles need to be disabled if a permission is changed
     // or the role is enabled as a result of a double-nested role
     // or the role is the actual role being modified
@@ -149,7 +149,7 @@ export function adminRoleController(
     );
   };
 
-  $scope.isPermissionDisabled = function (nestedPermissionName) {
+  $scope.isPermissionDisabled = function(nestedPermissionName) {
     // Permissions need to be disabled if a role is changed
     // or the permission is enabled as a result of a nested role
     return (
@@ -158,9 +158,9 @@ export function adminRoleController(
     );
   };
 
-  $scope.roleChange = function (roleName) {
-    let changed = $scope.selectedRole;
-    let original = _.find($scope.serverRoles, { id: changed.id });
+  $scope.roleChange = function(roleName) {
+    const changed = $scope.selectedRole;
+    const original = _.find($scope.serverRoles, {id: changed.id});
 
     // Since this is a result of a click, we need to update primary roles
     changed.primaryRoles[roleName] = changed.roles[roleName];
@@ -170,56 +170,56 @@ export function adminRoleController(
     // permissions that are a result of nested roles) and then add the primary
     // permissions back
     // First, let's get the list of primary permissions
-    let primaryPermissionNames = mapToArray(changed.primaryPermissions);
+    const primaryPermissionNames = mapToArray(changed.primaryPermissions);
 
     // Then get the list of roles that are checked
-    let primaryRoleNames = mapToArray(changed.primaryRoles);
+    const primaryRoleNames = mapToArray(changed.primaryRoles);
 
     // Now we need the actual role definitions for those roles...
-    let primaryRoleList = _.filter(
-      $scope.raws.roles,
-      (value, key, collection) => {
-        return _.indexOf(primaryRoleNames, value.name) !== -1;
-      }
+    const primaryRoleList = _.filter(
+        $scope.raws.roles,
+        (value, key, collection) => {
+          return _.indexOf(primaryRoleNames, value.name) !== -1;
+        }
     );
 
     // ...so that we can calculate nested permissions...
-    let coalesced = RoleService.coalescePermissions(primaryRoleList);
-    let nestedPermissionNames = coalesced[1];
+    const coalesced = RoleService.coalescePermissions(primaryRoleList);
+    const nestedPermissionNames = coalesced[1];
 
     // And then combine them into one big list o' permissions
-    let allPermissionNames = _.union(
-      primaryPermissionNames,
-      nestedPermissionNames
+    const allPermissionNames = _.union(
+        primaryPermissionNames,
+        nestedPermissionNames
     );
 
     // Finally, convert that list back into the map angular wants
-    let permissionMap = arrayToMap(allPermissionNames, $scope.raws.permissions);
+    const permissionMap = arrayToMap(allPermissionNames, $scope.raws.permissions);
     changed.permissions = permissionMap;
 
     // Now deal with roles too
-    let allRoleNames = coalesced[0];
-    let nestedRoleNames = _.difference(allRoleNames, primaryRoleNames);
+    const allRoleNames = coalesced[0];
+    const nestedRoleNames = _.difference(allRoleNames, primaryRoleNames);
 
-    let roleMap = arrayToMap(allRoleNames, $scope.roleNames);
+    const roleMap = arrayToMap(allRoleNames, $scope.roleNames);
     changed.roles = roleMap;
 
-    let nestedRoleMap = arrayToMap(nestedRoleNames, $scope.roleNames);
+    const nestedRoleMap = arrayToMap(nestedRoleNames, $scope.roleNames);
     changed.nestedRoles = nestedRoleMap;
 
     // Finally, need to determine if the nested roles have been changed so
     // that we can enable or disable changing the permissions
     changed.rolesChanged = false;
-    for (let key in changed.roles) {
+    for (const key in changed.roles) {
       if (changed.roles[key] != original.roles[key]) {
         changed.rolesChanged = true;
       }
     }
   };
 
-  $scope.permissionChange = function (permission) {
-    let changed = $scope.selectedRole;
-    let original = _.find($scope.serverRoles, { id: changed.id });
+  $scope.permissionChange = function(permission) {
+    const changed = $scope.selectedRole;
+    const original = _.find($scope.serverRoles, {id: changed.id});
 
     // Since this is a result of a click, we need to update primary permissions
     changed.primaryPermissions[permission] = changed.permissions[permission];
@@ -239,103 +239,103 @@ export function adminRoleController(
       permissions: PermissionService.getPermissions(),
       roles: RoleService.getRoles(),
     }).then(
-      (responses) => {
+        (responses) => {
         // Success callback is only invoked if all promises are resolved, so just
         // pick one to let the fetch-data directive know about the success
-        $scope.response = responses.roles;
+          $scope.response = responses.roles;
 
-        $scope.raws = {
-          permissions: responses.permissions.data,
-          roles: responses.roles.data,
-        };
+          $scope.raws = {
+            permissions: responses.permissions.data,
+            roles: responses.roles.data,
+          };
 
-        $scope.roleNames = _.map($scope.raws.roles, "name");
-        $scope.permissions = _.groupBy($scope.raws.permissions, (value) => {
-          return value.split("-").slice(0, 2).join("-");
-        });
+          $scope.roleNames = _.map($scope.raws.roles, 'name');
+          $scope.permissions = _.groupBy($scope.raws.permissions, (value) => {
+            return value.split('-').slice(0, 2).join('-');
+          });
 
-        // Load into the form we can work with
-        let thaRoles = [];
+          // Load into the form we can work with
+          const thaRoles = [];
 
-        for (let role of $scope.raws.roles) {
+          for (const role of $scope.raws.roles) {
           // Need to make a distinction between roles / permissions that are
           // attached to this role (that will be editable) and those that are
           // inherited because of nested roles
 
-          let primaryRoleNames = _.map(role.roles, "name");
-          let primaryPermissionNames = role.permissions;
+            const primaryRoleNames = _.map(role.roles, 'name');
+            const primaryPermissionNames = role.permissions;
 
-          let coalesced = RoleService.coalescePermissions(role.roles);
+            const coalesced = RoleService.coalescePermissions(role.roles);
 
-          let allRoleNames = coalesced[0];
-          let nestedPermissionNames = coalesced[1];
+            const allRoleNames = coalesced[0];
+            const nestedPermissionNames = coalesced[1];
 
-          let nestedRoleNames = _.difference(allRoleNames, primaryRoleNames);
-          let allPermissionNames = _.union(
-            primaryPermissionNames,
-            coalesced[1]
-          );
+            const nestedRoleNames = _.difference(allRoleNames, primaryRoleNames);
+            const allPermissionNames = _.union(
+                primaryPermissionNames,
+                coalesced[1]
+            );
 
-          let roleMap = arrayToMap(allRoleNames, $scope.roleNames);
-          let permissionMap = arrayToMap(
-            allPermissionNames,
-            $scope.raws.permissions
-          );
+            const roleMap = arrayToMap(allRoleNames, $scope.roleNames);
+            const permissionMap = arrayToMap(
+                allPermissionNames,
+                $scope.raws.permissions
+            );
 
-          let primaryRoleMap = arrayToMap(primaryRoleNames, $scope.roleNames);
-          let primaryPermissionMap = arrayToMap(
-            primaryPermissionNames,
-            $scope.raws.permissions
-          );
+            const primaryRoleMap = arrayToMap(primaryRoleNames, $scope.roleNames);
+            const primaryPermissionMap = arrayToMap(
+                primaryPermissionNames,
+                $scope.raws.permissions
+            );
 
-          let nestedRoleMap = arrayToMap(nestedRoleNames, $scope.roleNames);
-          let nestedPermissionMap = arrayToMap(
-            nestedPermissionNames,
-            $scope.raws.permissions
-          );
+            const nestedRoleMap = arrayToMap(nestedRoleNames, $scope.roleNames);
+            const nestedPermissionMap = arrayToMap(
+                nestedPermissionNames,
+                $scope.raws.permissions
+            );
 
-          thaRoles.push({
-            id: role.id,
-            name: role.name,
+            thaRoles.push({
+              id: role.id,
+              name: role.name,
 
-            roles: roleMap,
-            permissions: permissionMap,
+              roles: roleMap,
+              permissions: permissionMap,
 
-            primaryRoles: primaryRoleMap,
-            primaryPermissions: primaryPermissionMap,
+              primaryRoles: primaryRoleMap,
+              primaryPermissions: primaryPermissionMap,
 
-            nestedRoles: nestedRoleMap,
-            nestedPermissions: nestedPermissionMap,
+              nestedRoles: nestedRoleMap,
+              nestedPermissions: nestedPermissionMap,
 
-            rolesChanged: false,
-            permissionsChanged: false,
-          });
+              rolesChanged: false,
+              permissionsChanged: false,
+            });
+          }
+
+          // This is super annoying, but I can't find a better way
+          // Save off the current selection ID so we can keep it selected
+          const selectedId = $scope.selectedRole['id'];
+          let selectedRole = undefined;
+
+          $scope.serverRoles = _.cloneDeep(thaRoles);
+          $scope.roles = _.cloneDeep(thaRoles);
+
+          if (selectedId) {
+            selectedRole = _.find($scope.roles, {id: selectedId});
+          }
+          $scope.selectedRole = selectedRole || $scope.roles[0];
+
+          $scope.loader.loaded = true;
+          $scope.loader.error = false;
+          $scope.loader.errorMessage = undefined;
+        },
+        (response) => {
+          $scope.response = response;
         }
-
-        // This is super annoying, but I can't find a better way
-        // Save off the current selection ID so we can keep it selected
-        let selectedId = $scope.selectedRole["id"];
-        let selectedRole = undefined;
-
-        $scope.serverRoles = _.cloneDeep(thaRoles);
-        $scope.roles = _.cloneDeep(thaRoles);
-
-        if (selectedId) {
-          selectedRole = _.find($scope.roles, { id: selectedId });
-        }
-        $scope.selectedRole = selectedRole || $scope.roles[0];
-
-        $scope.loader.loaded = true;
-        $scope.loader.error = false;
-        $scope.loader.errorMessage = undefined;
-      },
-      (response) => {
-        $scope.response = response;
-      }
     );
   }
 
-  $scope.$on("userChange", () => {
+  $scope.$on('userChange', () => {
     $scope.response = undefined;
     loadAll();
   });
@@ -343,7 +343,7 @@ export function adminRoleController(
   loadAll();
 }
 
-newRoleController.$inject = ["$scope", "$uibModalInstance"];
+newRoleController.$inject = ['$scope', '$uibModalInstance'];
 
 /**
  * newRoleController - New Role controller.
@@ -353,11 +353,11 @@ newRoleController.$inject = ["$scope", "$uibModalInstance"];
 export function newRoleController($scope, $uibModalInstance) {
   $scope.create = {};
 
-  $scope.ok = function () {
+  $scope.ok = function() {
     $uibModalInstance.close($scope.create);
   };
 
-  $scope.cancel = function () {
-    $uibModalInstance.dismiss("cancel");
+  $scope.cancel = function() {
+    $uibModalInstance.dismiss('cancel');
   };
 }

--- a/src/ui/src/js/controllers/admin_role.js
+++ b/src/ui/src/js/controllers/admin_role.js
@@ -24,7 +24,7 @@ export function adminRoleController(
     $q,
     $uibModal,
     RoleService,
-    PermissionService
+    PermissionService,
 ) {
   $scope.setWindowTitle('roles');
 
@@ -55,7 +55,7 @@ export function adminRoleController(
           RoleService.createRole(create).then(loadAll);
         },
         // We don't really need to do anything if canceled
-        () => {}
+        () => {},
     );
   };
 
@@ -180,7 +180,7 @@ export function adminRoleController(
         $scope.raws.roles,
         (value, key, collection) => {
           return _.indexOf(primaryRoleNames, value.name) !== -1;
-        }
+        },
     );
 
     // ...so that we can calculate nested permissions...
@@ -190,7 +190,7 @@ export function adminRoleController(
     // And then combine them into one big list o' permissions
     const allPermissionNames = _.union(
         primaryPermissionNames,
-        nestedPermissionNames
+        nestedPermissionNames,
     );
 
     // Finally, convert that list back into the map angular wants
@@ -273,25 +273,25 @@ export function adminRoleController(
             const nestedRoleNames = _.difference(allRoleNames, primaryRoleNames);
             const allPermissionNames = _.union(
                 primaryPermissionNames,
-                coalesced[1]
+                coalesced[1],
             );
 
             const roleMap = arrayToMap(allRoleNames, $scope.roleNames);
             const permissionMap = arrayToMap(
                 allPermissionNames,
-                $scope.raws.permissions
+                $scope.raws.permissions,
             );
 
             const primaryRoleMap = arrayToMap(primaryRoleNames, $scope.roleNames);
             const primaryPermissionMap = arrayToMap(
                 primaryPermissionNames,
-                $scope.raws.permissions
+                $scope.raws.permissions,
             );
 
             const nestedRoleMap = arrayToMap(nestedRoleNames, $scope.roleNames);
             const nestedPermissionMap = arrayToMap(
                 nestedPermissionNames,
-                $scope.raws.permissions
+                $scope.raws.permissions,
             );
 
             thaRoles.push({
@@ -331,7 +331,7 @@ export function adminRoleController(
         },
         (response) => {
           $scope.response = response;
-        }
+        },
     );
   }
 

--- a/src/ui/src/js/controllers/admin_system.js
+++ b/src/ui/src/js/controllers/admin_system.js
@@ -40,7 +40,7 @@ export default function adminSystemController(
     AdminService,
     QueueService,
     RunnerService,
-    EventService
+    EventService,
 ) {
   $scope.response = undefined;
   $scope.runnerResponse = undefined;
@@ -88,7 +88,7 @@ export default function adminSystemController(
   $scope.clearAllQueues = function() {
     QueueService.clearQueues().then(
         $scope.addSuccessAlert,
-        $scope.addErrorAlert
+        $scope.addErrorAlert,
     );
   };
 

--- a/src/ui/src/js/controllers/admin_system.js
+++ b/src/ui/src/js/controllers/admin_system.js
@@ -1,26 +1,27 @@
-import _ from "lodash";
-import readLogs from "../../templates/read_logs.html";
-import adminQueue from "../../templates/admin_queue.html";
-import forceDelete from "../../templates/system_force_delete.html";
-import { responseState } from "../services/utility_service.js";
+import _ from 'lodash';
+import readLogs from '../../templates/read_logs.html';
+import adminQueue from '../../templates/admin_queue.html';
+import forceDelete from '../../templates/system_force_delete.html';
+import {responseState} from '../services/utility_service.js';
 
 adminSystemController.$inject = [
-  "$scope",
-  "$rootScope",
-  "$uibModal",
-  "SystemService",
-  "InstanceService",
-  "UtilityService",
-  "AdminService",
-  "QueueService",
-  "RunnerService",
-  "EventService",
+  '$scope',
+  '$rootScope',
+  '$uibModal',
+  'SystemService',
+  'InstanceService',
+  'UtilityService',
+  'AdminService',
+  'QueueService',
+  'RunnerService',
+  'EventService',
 ];
 
 /**
  * adminSystemController - System management controller.
  * @param  {Object} $scope          Angular's $scope object.
  * @param  {Object} $rootScope      Angular's $rootScope object.
+ * @param  {Object} $uibModal       Modal
  * @param  {Object} SystemService   Beer-Garden's system service object.
  * @param  {Object} InstanceService Beer-Garden's instance service object.
  * @param  {Object} UtilityService  Beer-Garden's utility service object.
@@ -30,16 +31,16 @@ adminSystemController.$inject = [
  * @param  {Object} EventService    Beer-Garden's event service object.
  */
 export default function adminSystemController(
-  $scope,
-  $rootScope,
-  $uibModal,
-  SystemService,
-  InstanceService,
-  UtilityService,
-  AdminService,
-  QueueService,
-  RunnerService,
-  EventService
+    $scope,
+    $rootScope,
+    $uibModal,
+    SystemService,
+    InstanceService,
+    UtilityService,
+    AdminService,
+    QueueService,
+    RunnerService,
+    EventService
 ) {
   $scope.response = undefined;
   $scope.runnerResponse = undefined;
@@ -49,27 +50,27 @@ export default function adminSystemController(
   $scope.showRunnersTile = false;
   $scope.groupedRunners = [];
 
-  $scope.setWindowTitle("systems");
+  $scope.setWindowTitle('systems');
 
   $scope.getIcon = UtilityService.getIcon;
 
-  $scope.rescan = function () {
+  $scope.rescan = function() {
     AdminService.rescan().then(_.noop, $scope.addErrorAlert);
   };
 
-  $scope.startSystem = function (system) {
+  $scope.startSystem = function(system) {
     _.forEach(system.instances, $scope.startInstance);
   };
 
-  $scope.stopSystem = function (system) {
+  $scope.stopSystem = function(system) {
     _.forEach(system.instances, $scope.stopInstance);
   };
 
-  $scope.reloadSystem = function (system) {
+  $scope.reloadSystem = function(system) {
     SystemService.reloadSystem(system).then(_.noop, $scope.addErrorAlert);
   };
 
-  $scope.deleteSystem = function (system) {
+  $scope.deleteSystem = function(system) {
     $scope.deletedSystem = system;
     SystemService.deleteSystem(system).then(_.noop, (response) => {
       $uibModal.open({
@@ -78,39 +79,39 @@ export default function adminSystemController(
           system: $scope.deletedSystem,
           response: response,
         },
-        controller: "AdminSystemForceDeleteController",
-        windowClass: "app-modal-window",
+        controller: 'AdminSystemForceDeleteController',
+        windowClass: 'app-modal-window',
       });
     });
   };
 
-  $scope.clearAllQueues = function () {
+  $scope.clearAllQueues = function() {
     QueueService.clearQueues().then(
-      $scope.addSuccessAlert,
-      $scope.addErrorAlert
+        $scope.addSuccessAlert,
+        $scope.addErrorAlert
     );
   };
 
-  $scope.hasRunningInstances = function (system) {
+  $scope.hasRunningInstances = function(system) {
     return system.instances.some((instance) => {
-      return instance.status == "RUNNING";
+      return instance.status == 'RUNNING';
     });
   };
 
-  $scope.startInstance = function (instance) {
+  $scope.startInstance = function(instance) {
     InstanceService.startInstance(instance).catch($scope.addErrorAlert);
   };
 
-  $scope.stopInstance = function (instance) {
+  $scope.stopInstance = function(instance) {
     InstanceService.stopInstance(instance).catch($scope.addErrorAlert);
   };
 
-  $scope.startRunner = function (runner) {
+  $scope.startRunner = function(runner) {
     runner.waiting = true;
     RunnerService.startRunner(runner).catch($scope.addErrorAlert);
   };
 
-  $scope.stopRunner = function (runner) {
+  $scope.stopRunner = function(runner) {
     runner.waiting = true;
     RunnerService.stopRunner(runner).catch($scope.addErrorAlert);
   };
@@ -120,40 +121,40 @@ export default function adminSystemController(
     RunnerService.removeRunner(runner).catch($scope.addErrorAlert);
   };
 
-  $scope.startRunners = function (runnerList) {
+  $scope.startRunners = function(runnerList) {
     _.forEach(runnerList, $scope.startRunner);
   };
 
-  $scope.stopRunners = function (runnerList) {
+  $scope.stopRunners = function(runnerList) {
     _.forEach(runnerList, $scope.stopRunner);
   };
 
-  $scope.reloadRunners = function (runnerList) {
+  $scope.reloadRunners = function(runnerList) {
     RunnerService.reloadRunners(runnerList[0].path).catch($scope.addErrorAlert);
   };
 
-  $scope.deleteRunners = function (runnerList) {
+  $scope.deleteRunners = function(runnerList) {
     _.forEach(runnerList, $scope.deleteRunner);
   };
 
-  $scope.isRunnerUnassociated = function (runner) {
+  $scope.isRunnerUnassociated = function(runner) {
     return instanceFromRunner(runner) === undefined;
   };
 
-  $scope.runnerInstanceName = function (runner) {
-    return runner.instance ? runner.instance.name : "UNKNOWN";
+  $scope.runnerInstanceName = function(runner) {
+    return runner.instance ? runner.instance.name : 'UNKNOWN';
   };
 
-  $scope.addErrorAlert = function (response) {
+  $scope.addErrorAlert = function(response) {
     $scope.alerts.push({
-      type: "danger",
+      type: 'danger',
       msg:
-        "Something went wrong on the backend: " +
-        _.get(response, "data.message", "Please check the server logs"),
+        'Something went wrong on the backend: ' +
+        _.get(response, 'data.message', 'Please check the server logs'),
     });
   };
 
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
@@ -161,7 +162,7 @@ export default function adminSystemController(
     if ($rootScope.systems) {
       $scope.response = $rootScope.sysResponse;
 
-      let grouped = _.groupBy($rootScope.systems, (value) => {
+      const grouped = _.groupBy($rootScope.systems, (value) => {
         return value.display_name || value.name;
       });
       $scope.groupedSystems = _.sortBy(grouped, (sysList) => {
@@ -176,7 +177,7 @@ export default function adminSystemController(
     if ($scope.runners) {
       $scope.showRunnersTile = false;
 
-      for (let runner of $scope.runners) {
+      for (const runner of $scope.runners) {
         runner.instance = instanceFromRunner(runner);
 
         if ($scope.isRunnerUnassociated(runner)) {
@@ -184,7 +185,7 @@ export default function adminSystemController(
         }
       }
 
-      let grouped = _.groupBy($scope.runners, (value) => {
+      const grouped = _.groupBy($scope.runners, (value) => {
         return value.path;
       });
       $scope.groupedRunners = _.sortBy(grouped, (runnerList) => {
@@ -195,8 +196,8 @@ export default function adminSystemController(
     }
   }
 
-  $scope.hasUnassociatedRunners = function (runners) {
-    for (let runner of runners) {
+  $scope.hasUnassociatedRunners = function(runners) {
+    for (const runner of runners) {
       if ($scope.isRunnerUnassociated(runner)) {
         return true;
       }
@@ -204,59 +205,59 @@ export default function adminSystemController(
     return false;
   };
 
-  $rootScope.$watchCollection("systems", groupSystems);
+  $rootScope.$watchCollection('systems', groupSystems);
 
-  $scope.showLogs = function (system, instance) {
+  $scope.showLogs = function(system, instance) {
     $uibModal.open({
       template: readLogs,
       resolve: {
         system: system,
         instance: instance,
       },
-      controller: "AdminSystemLogsController",
-      windowClass: "app-modal-window",
+      controller: 'AdminSystemLogsController',
+      windowClass: 'app-modal-window',
     });
   };
 
-  $scope.manageQueue = function (system, instance) {
+  $scope.manageQueue = function(system, instance) {
     $uibModal.open({
       template: adminQueue,
       resolve: {
         system: system,
         instance: instance,
       },
-      controller: "AdminQueueController",
-      windowClass: "app-modal-window",
+      controller: 'AdminQueueController',
+      windowClass: 'app-modal-window',
     });
   };
 
   function eventCallback(event) {
-    if (event.name.startsWith("RUNNER")) {
+    if (event.name.startsWith('RUNNER')) {
       _.remove($scope.runners, (value) => {
         return value.id == event.payload.id;
       });
 
-      if (event.name != "RUNNER_REMOVED") {
+      if (event.name != 'RUNNER_REMOVED') {
         $scope.runners.push(event.payload);
       }
       groupRunners();
-    } else if (event.name.startsWith("INSTANCE")) {
+    } else if (event.name.startsWith('INSTANCE')) {
       groupRunners();
     }
   }
 
-  EventService.addCallback("admin_system", (event) => {
+  EventService.addCallback('admin_system', (event) => {
     $scope.$apply(() => {
       eventCallback(event);
     });
   });
-  $scope.$on("$destroy", function () {
-    EventService.removeCallback("admin_system");
+  $scope.$on('$destroy', function() {
+    EventService.removeCallback('admin_system');
   });
 
   function instanceFromRunner(runner) {
-    for (let system of $rootScope.systems) {
-      for (let instance of system.instances) {
+    for (const system of $rootScope.systems) {
+      for (const instance of system.instances) {
         if (instance.metadata.runner_id == runner.id) {
           return instance;
         }
@@ -273,7 +274,7 @@ export default function adminSystemController(
     $scope.runners = response.data;
 
     // This is kind of messy, but oh well
-    if (responseState($scope.response) === "empty") {
+    if (responseState($scope.response) === 'empty') {
       $scope.response = response;
     }
 

--- a/src/ui/src/js/controllers/admin_system_force_delete.js
+++ b/src/ui/src/js/controllers/admin_system_force_delete.js
@@ -1,47 +1,51 @@
-import angular from "angular";
+// eslint-disable-next-line no-unused-vars
+import angular from 'angular';
 
 adminSystemForceDeleteController.$inject = [
-  "$scope",
-  "$uibModalInstance",
-  "SystemService",
-  "system",
-  "response",
+  '$scope',
+  '$uibModalInstance',
+  'SystemService',
+  'system',
+  'response',
 ];
 
 /**
  * adminSystemForceDeleteController - Angular controller for force deleting systems.
- * @param  {Object} $rootScope        Angular's $rootScope object.
+ * @param  {Object} $scope        Angular's $scope object.
+ * @param  {Object} $uibModalInstance Modal
  * @param  {Object} SystemService     Beer-Garden's system service object.
+ * @param  {Object} system            System
+ * @param  {Object} response          Response
  */
 export default function adminSystemForceDeleteController(
-  $scope,
-  $uibModalInstance,
-  SystemService,
-  system,
-  response
+    $scope,
+    $uibModalInstance,
+    SystemService,
+    system,
+    response
 ) {
   $scope.alerts = [];
   $scope.system = system;
   $scope.error = response.data.message;
 
-  $scope.forceDeleteSystem = function (system) {
-    SystemService.forceDeleteSystem(system).then(function (response) {
+  $scope.forceDeleteSystem = function(system) {
+    SystemService.forceDeleteSystem(system).then(function(response) {
       $uibModalInstance.close();
     }, $scope.addErrorAlert);
   };
 
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
-  $scope.addErrorAlert = function (response) {
+  $scope.addErrorAlert = function(response) {
     $scope.alerts.push({
-      type: "danger",
-      msg: _.get(response, "data.message", "Please check the server logs"),
+      type: 'danger',
+      msg: _.get(response, 'data.message', 'Please check the server logs'),
     });
   };
 
-  $scope.closeDialog = function () {
+  $scope.closeDialog = function() {
     $uibModalInstance.close();
   };
 }

--- a/src/ui/src/js/controllers/admin_system_force_delete.js
+++ b/src/ui/src/js/controllers/admin_system_force_delete.js
@@ -22,7 +22,7 @@ export default function adminSystemForceDeleteController(
     $uibModalInstance,
     SystemService,
     system,
-    response
+    response,
 ) {
   $scope.alerts = [];
   $scope.system = system;

--- a/src/ui/src/js/controllers/admin_system_logs.js
+++ b/src/ui/src/js/controllers/admin_system_logs.js
@@ -19,7 +19,7 @@ export default function adminSystemLogsController(
     $uibModalInstance,
     InstanceService,
     system,
-    instance
+    instance,
 ) {
   $scope.logs = undefined;
   $scope.start_line = 0;
@@ -70,7 +70,7 @@ export default function adminSystemLogsController(
         instance.id,
         $scope.wait_timeout,
         $scope.start_line,
-        $scope.end_line
+        $scope.end_line,
     ).then($scope.successLogs, $scope.addErrorAlert);
   };
 
@@ -82,7 +82,7 @@ export default function adminSystemLogsController(
         instance.id,
         $scope.wait_timeout,
         $scope.tail_line * -1,
-        null
+        null,
     ).then($scope.successLogs, $scope.addErrorAlert);
   };
 
@@ -94,7 +94,7 @@ export default function adminSystemLogsController(
         instance.id,
         $scope.wait_timeout,
         null,
-        null
+        null,
     ).then($scope.successLogs, $scope.addErrorAlert);
   };
 

--- a/src/ui/src/js/controllers/admin_system_logs.js
+++ b/src/ui/src/js/controllers/admin_system_logs.js
@@ -1,24 +1,25 @@
 adminSystemLogsController.$inject = [
-  "$scope",
-  "$uibModalInstance",
-  "InstanceService",
-  "system",
-  "instance",
+  '$scope',
+  '$uibModalInstance',
+  'InstanceService',
+  'system',
+  'instance',
 ];
 
 /**
  * adminSystemController - System management controller.
- * @param  {Object} $scope          Angular's $scope object.
- * @param  {Object} $rootScope      Angular's $rootScope object.
- * @param  {Object} SystemService   Beer-Garden's system service object.
- * @param  {Object} InstanceService Beer-Garden's instance service object.
+ * @param  {Object} $scope            Angular's $scope object.
+ * @param  {Object} $uibModalInstance Modal
+ * @param  {Object} InstanceService   Beer-Garden's instance service object.
+ * @param  {Object} system            System
+ * @param  {Object} instance          Instance
  */
 export default function adminSystemLogsController(
-  $scope,
-  $uibModalInstance,
-  InstanceService,
-  system,
-  instance
+    $scope,
+    $uibModalInstance,
+    InstanceService,
+    system,
+    instance
 ) {
   $scope.logs = undefined;
   $scope.start_line = 0;
@@ -31,87 +32,87 @@ export default function adminSystemLogsController(
   $scope.loadingLogs = false;
   $scope.alerts = [
     {
-      type: "info",
+      type: 'info',
       msg:
-        "Plugin must be listening to the Admin Queue " +
-        "and logging to File for logs to be returned. " +
-        "This will only return information from the log file being actively written to.",
+        'Plugin must be listening to the Admin Queue ' +
+        'and logging to File for logs to be returned. ' +
+        'This will only return information from the log file being actively written to.',
     },
   ];
 
   $scope.downloadHref = undefined;
   $scope.filename =
     $scope.system.name +
-    "[" +
+    '[' +
     $scope.system.version +
-    "]-" +
+    ']-' +
     $scope.instance.name +
-    ".log";
+    '.log';
 
-  $scope.successLogs = function (response) {
+  $scope.successLogs = function(response) {
     $scope.loadingLogs = false;
     $scope.logs = response.data;
-    $scope.displayLogs = "";
-    $scope.requestId = response.headers("request_id");
+    $scope.displayLogs = '';
+    $scope.requestId = response.headers('request_id');
 
-    for (var i = 0; i < $scope.logs.length; i++) {
+    for (let i = 0; i < $scope.logs.length; i++) {
       $scope.displayLogs = $scope.displayLogs.concat($scope.logs[i]);
     }
 
-    $scope.downloadHref = "api/v1/requests/output/" + $scope.requestId;
+    $scope.downloadHref = 'api/v1/requests/output/' + $scope.requestId;
   };
 
-  $scope.getLogsLines = function () {
+  $scope.getLogsLines = function() {
     $scope.loadingLogs = true;
     $scope.displayLogs = undefined;
 
     InstanceService.getInstanceLogs(
-      instance.id,
-      $scope.wait_timeout,
-      $scope.start_line,
-      $scope.end_line
+        instance.id,
+        $scope.wait_timeout,
+        $scope.start_line,
+        $scope.end_line
     ).then($scope.successLogs, $scope.addErrorAlert);
   };
 
-  $scope.getLogsTail = function () {
+  $scope.getLogsTail = function() {
     $scope.loadingLogs = true;
     $scope.displayLogs = undefined;
 
     InstanceService.getInstanceLogs(
-      instance.id,
-      $scope.wait_timeout,
-      $scope.tail_line * -1,
-      null
+        instance.id,
+        $scope.wait_timeout,
+        $scope.tail_line * -1,
+        null
     ).then($scope.successLogs, $scope.addErrorAlert);
   };
 
-  $scope.getLogs = function () {
+  $scope.getLogs = function() {
     $scope.loadingLogs = true;
     $scope.displayLogs = undefined;
 
     InstanceService.getInstanceLogs(
-      instance.id,
-      $scope.wait_timeout,
-      null,
-      null
+        instance.id,
+        $scope.wait_timeout,
+        null,
+        null
     ).then($scope.successLogs, $scope.addErrorAlert);
   };
 
-  $scope.closeDialog = function () {
+  $scope.closeDialog = function() {
     $uibModalInstance.close();
   };
 
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
-  $scope.addErrorAlert = function (response) {
+  $scope.addErrorAlert = function(response) {
     $scope.loadingLogs = false;
     $scope.alerts.push({
-      type: "danger",
+      type: 'danger',
       msg:
-        "Something went wrong on the backend: " +
-        _.get(response, "data.message", "Please check the server logs"),
+        'Something went wrong on the backend: ' +
+        _.get(response, 'data.message', 'Please check the server logs'),
     });
   };
 }

--- a/src/ui/src/js/controllers/admin_user.js
+++ b/src/ui/src/js/controllers/admin_user.js
@@ -27,7 +27,7 @@ export function adminUserController(
     $uibModal,
     RoleService,
     UserService,
-    PermissionService
+    PermissionService,
 ) {
   $scope.setWindowTitle('users');
 
@@ -57,12 +57,12 @@ export function adminUserController(
         (create) => {
           if (create.password === create.verify) {
             UserService.createUser(create.username, create.password).then(
-                loadUsers
+                loadUsers,
             );
           }
         },
         // We don't really need to do anything if canceled
-        () => {}
+        () => {},
     );
   };
 
@@ -152,7 +152,7 @@ export function adminUserController(
         $scope.raws.roles,
         (value, key, collection) => {
           return _.indexOf(primaryRoleNames, value.name) !== -1;
-        }
+        },
     );
 
     // ...so that we can calculate nested permissions...
@@ -196,7 +196,7 @@ export function adminUserController(
       const roleMap = arrayToMap(allRoleNames, $scope.roleNames);
       const permissionMap = arrayToMap(
           allPermissionNames,
-          $scope.raws.permissions
+          $scope.raws.permissions,
       );
 
       const primaryRoleMap = arrayToMap(primaryRoleNames, $scope.roleNames);
@@ -270,7 +270,7 @@ export function adminUserController(
         },
         (response) => {
           $scope.response = response;
-        }
+        },
     );
   }
 

--- a/src/ui/src/js/controllers/admin_user.js
+++ b/src/ui/src/js/controllers/admin_user.js
@@ -1,15 +1,15 @@
-import _ from "lodash";
-import { arrayToMap, mapToArray } from "../services/utility_service.js";
+import _ from 'lodash';
+import {arrayToMap, mapToArray} from '../services/utility_service.js';
 
-import template from "../../templates/new_user.html";
+import template from '../../templates/new_user.html';
 
 adminUserController.$inject = [
-  "$scope",
-  "$q",
-  "$uibModal",
-  "RoleService",
-  "UserService",
-  "PermissionService",
+  '$scope',
+  '$q',
+  '$uibModal',
+  'RoleService',
+  'UserService',
+  'PermissionService',
 ];
 
 /**
@@ -22,14 +22,14 @@ adminUserController.$inject = [
  * @param  {Object} PermissionService Beer-Garden's permission service object.
  */
 export function adminUserController(
-  $scope,
-  $q,
-  $uibModal,
-  RoleService,
-  UserService,
-  PermissionService
+    $scope,
+    $q,
+    $uibModal,
+    RoleService,
+    UserService,
+    PermissionService
 ) {
-  $scope.setWindowTitle("users");
+  $scope.setWindowTitle('users');
 
   // This holds the raw responses from the backend
   $scope.raws = {};
@@ -46,48 +46,48 @@ export function adminUserController(
   // Normal loader
   $scope.loader = {};
 
-  $scope.doCreate = function () {
-    let modalInstance = $uibModal.open({
-      controller: "NewUserController",
-      size: "sm",
+  $scope.doCreate = function() {
+    const modalInstance = $uibModal.open({
+      controller: 'NewUserController',
+      size: 'sm',
       template: template,
     });
 
     modalInstance.result.then(
-      (create) => {
-        if (create.password === create.verify) {
-          UserService.createUser(create.username, create.password).then(
-            loadUsers
-          );
-        }
-      },
-      // We don't really need to do anything if canceled
-      () => {}
+        (create) => {
+          if (create.password === create.verify) {
+            UserService.createUser(create.username, create.password).then(
+                loadUsers
+            );
+          }
+        },
+        // We don't really need to do anything if canceled
+        () => {}
     );
   };
 
-  $scope.doDelete = function (userId) {
+  $scope.doDelete = function(userId) {
     UserService.deleteUser(userId).then(loadUsers);
   };
 
-  $scope.doReset = function (userId) {
-    let original = _.find($scope.serverUsers, { id: userId });
-    let changed = _.find($scope.users, { id: userId });
+  $scope.doReset = function(userId) {
+    const original = _.find($scope.serverUsers, {id: userId});
+    const changed = _.find($scope.users, {id: userId});
 
     changed.roles = _.cloneDeep(original.roles);
     changed.permissions = _.cloneDeep(original.permissions);
   };
 
-  $scope.doUpdate = function () {
-    let userId = $scope.selectedUser.id;
-    let original = _.find($scope.serverUsers, { id: userId });
-    let promises = [];
+  $scope.doUpdate = function() {
+    const userId = $scope.selectedUser.id;
+    const original = _.find($scope.serverUsers, {id: userId});
+    const promises = [];
 
-    let originalList = mapToArray(original.primaryRoles);
-    let changedList = mapToArray($scope.selectedUser.primaryRoles);
+    const originalList = mapToArray(original.primaryRoles);
+    const changedList = mapToArray($scope.selectedUser.primaryRoles);
 
-    let additions = _.difference(changedList, originalList);
-    let removals = _.difference(originalList, changedList);
+    const additions = _.difference(changedList, originalList);
+    const removals = _.difference(originalList, changedList);
 
     if (additions.length) {
       promises.push(UserService.addRoles(userId, additions));
@@ -99,38 +99,38 @@ export function adminUserController(
     $q.all(promises).then(loadUsers, $scope.addErrorAlert);
   };
 
-  $scope.addErrorAlert = function (response) {
+  $scope.addErrorAlert = function(response) {
     $scope.alerts.push({
-      type: "danger",
+      type: 'danger',
       msg:
-        "Something went wrong on the backend: " +
-        _.get(response, "data.message", "Please check the server logs"),
+        'Something went wrong on the backend: ' +
+        _.get(response, 'data.message', 'Please check the server logs'),
     });
   };
 
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
-  $scope.color = function (userId, path) {
+  $scope.color = function(userId, path) {
     // Pull the correct users based on the current selected user's id
-    let originalSelectedUser = _.find($scope.serverUsers, { id: userId });
-    let changedSelectedUser = _.find($scope.users, { id: userId });
+    const originalSelectedUser = _.find($scope.serverUsers, {id: userId});
+    const changedSelectedUser = _.find($scope.users, {id: userId});
 
     // Now pull the original and changed values out
-    let originalValue = _.get(originalSelectedUser, path);
-    let changedValue = _.get(changedSelectedUser, path);
+    const originalValue = _.get(originalSelectedUser, path);
+    const changedValue = _.get(changedSelectedUser, path);
 
     if (changedValue && !originalValue) {
-      return { color: "green" };
+      return {color: 'green'};
     } else if (!changedValue && originalValue) {
-      return { color: "red" };
+      return {color: 'red'};
     }
 
     return {};
   };
 
-  $scope.isRoleDisabled = function (roleName) {
+  $scope.isRoleDisabled = function(roleName) {
     // Roles need to be disabled if it's enabled because it's nested
     return (
       $scope.selectedUser.roles[roleName] &&
@@ -138,39 +138,39 @@ export function adminUserController(
     );
   };
 
-  $scope.roleChange = function (roleName) {
-    let changed = $scope.selectedUser;
+  $scope.roleChange = function(roleName) {
+    const changed = $scope.selectedUser;
 
     // Since this is a result of a click, we need to update primary roles
     changed.primaryRoles[roleName] = changed.roles[roleName];
 
     // Then get the list of roles that are checked
-    let primaryRoleNames = mapToArray(changed.primaryRoles);
+    const primaryRoleNames = mapToArray(changed.primaryRoles);
 
     // Now we need the actual role definitions for those roles...
-    let primaryRoleList = _.filter(
-      $scope.raws.roles,
-      (value, key, collection) => {
-        return _.indexOf(primaryRoleNames, value.name) !== -1;
-      }
+    const primaryRoleList = _.filter(
+        $scope.raws.roles,
+        (value, key, collection) => {
+          return _.indexOf(primaryRoleNames, value.name) !== -1;
+        }
     );
 
     // ...so that we can calculate nested permissions...
-    let coalesced = RoleService.coalescePermissions(primaryRoleList);
-    let permissionNames = coalesced[1];
+    const coalesced = RoleService.coalescePermissions(primaryRoleList);
+    const permissionNames = coalesced[1];
 
     // Finally, convert that list back into the map angular wants
-    let permissionMap = arrayToMap(permissionNames, $scope.raws.permissions);
+    const permissionMap = arrayToMap(permissionNames, $scope.raws.permissions);
     changed.permissions = permissionMap;
 
     // Now deal with roles too
-    let allRoleNames = coalesced[0];
-    let nestedRoleNames = _.difference(allRoleNames, primaryRoleNames);
+    const allRoleNames = coalesced[0];
+    const nestedRoleNames = _.difference(allRoleNames, primaryRoleNames);
 
-    let roleMap = arrayToMap(allRoleNames, $scope.roleNames);
+    const roleMap = arrayToMap(allRoleNames, $scope.roleNames);
     changed.roles = roleMap;
 
-    let nestedRoleMap = arrayToMap(nestedRoleNames, $scope.roleNames);
+    const nestedRoleMap = arrayToMap(nestedRoleNames, $scope.roleNames);
     changed.nestedRoles = nestedRoleMap;
   };
 
@@ -181,26 +181,26 @@ export function adminUserController(
   function handleUsersResponse(response) {
     $scope.raws.users = response.data;
 
-    let thaUsers = [];
+    const thaUsers = [];
 
-    for (let user of $scope.raws.users) {
-      let primaryRoleNames = _.map(user.roles, "name");
+    for (const user of $scope.raws.users) {
+      const primaryRoleNames = _.map(user.roles, 'name');
 
-      let coalesced = RoleService.coalescePermissions(user.roles);
+      const coalesced = RoleService.coalescePermissions(user.roles);
 
-      let allRoleNames = coalesced[0];
+      const allRoleNames = coalesced[0];
 
-      let nestedRoleNames = _.difference(allRoleNames, primaryRoleNames);
-      let allPermissionNames = coalesced[1];
+      const nestedRoleNames = _.difference(allRoleNames, primaryRoleNames);
+      const allPermissionNames = coalesced[1];
 
-      let roleMap = arrayToMap(allRoleNames, $scope.roleNames);
-      let permissionMap = arrayToMap(
-        allPermissionNames,
-        $scope.raws.permissions
+      const roleMap = arrayToMap(allRoleNames, $scope.roleNames);
+      const permissionMap = arrayToMap(
+          allPermissionNames,
+          $scope.raws.permissions
       );
 
-      let primaryRoleMap = arrayToMap(primaryRoleNames, $scope.roleNames);
-      let nestedRoleMap = arrayToMap(nestedRoleNames, $scope.roleNames);
+      const primaryRoleMap = arrayToMap(primaryRoleNames, $scope.roleNames);
+      const nestedRoleMap = arrayToMap(nestedRoleNames, $scope.roleNames);
 
       thaUsers.push({
         id: user.id,
@@ -216,14 +216,14 @@ export function adminUserController(
 
     // This is super annoying, but I can't find a better way
     // Save off the current selection ID so we can keep it selected
-    let selectedId = $scope.selectedUser["id"];
+    const selectedId = $scope.selectedUser['id'];
     let selectedUser = undefined;
 
     $scope.serverUsers = _.cloneDeep(thaUsers);
     $scope.users = _.cloneDeep(thaUsers);
 
     if (selectedId) {
-      selectedUser = _.find($scope.users, { id: selectedId });
+      selectedUser = _.find($scope.users, {id: selectedId});
     }
     $scope.selectedUser = selectedUser || $scope.users[0];
   }
@@ -246,35 +246,35 @@ export function adminUserController(
       roles: RoleService.getRoles(),
       users: UserService.getUsers(),
     }).then(
-      (responses) => {
+        (responses) => {
         // Success callback is only invoked if all promises are resolved, so just
         // pick one to let the fetch-data directive know about the success
-        $scope.response = responses.users;
+          $scope.response = responses.users;
 
-        $scope.raws = {
-          permissions: responses.permissions.data,
-          roles: responses.roles.data,
-          users: responses.users.data,
-        };
+          $scope.raws = {
+            permissions: responses.permissions.data,
+            roles: responses.roles.data,
+            users: responses.users.data,
+          };
 
-        $scope.roleNames = _.map($scope.raws.roles, "name");
-        $scope.permissions = _.groupBy($scope.raws.permissions, (value) => {
-          return value.split("-").slice(0, 2).join("-");
-        });
+          $scope.roleNames = _.map($scope.raws.roles, 'name');
+          $scope.permissions = _.groupBy($scope.raws.permissions, (value) => {
+            return value.split('-').slice(0, 2).join('-');
+          });
 
-        handleUsersResponse(responses.users);
+          handleUsersResponse(responses.users);
 
-        $scope.loader.loaded = true;
-        $scope.loader.error = false;
-        $scope.loader.errorMessage = undefined;
-      },
-      (response) => {
-        $scope.response = response;
-      }
+          $scope.loader.loaded = true;
+          $scope.loader.error = false;
+          $scope.loader.errorMessage = undefined;
+        },
+        (response) => {
+          $scope.response = response;
+        }
     );
   }
 
-  $scope.$on("userChange", () => {
+  $scope.$on('userChange', () => {
     $scope.response = undefined;
     loadAll();
   });
@@ -282,7 +282,7 @@ export function adminUserController(
   loadAll();
 }
 
-newUserController.$inject = ["$scope", "$uibModalInstance"];
+newUserController.$inject = ['$scope', '$uibModalInstance'];
 
 /**
  * newUserController - New User controller.
@@ -292,11 +292,11 @@ newUserController.$inject = ["$scope", "$uibModalInstance"];
 export function newUserController($scope, $uibModalInstance) {
   $scope.create = {};
 
-  $scope.ok = function () {
+  $scope.ok = function() {
     $uibModalInstance.close($scope.create);
   };
 
-  $scope.cancel = function () {
-    $uibModalInstance.dismiss("cancel");
+  $scope.cancel = function() {
+    $uibModalInstance.dismiss('cancel');
   };
 }

--- a/src/ui/src/js/controllers/command_index.js
+++ b/src/ui/src/js/controllers/command_index.js
@@ -25,7 +25,7 @@ export default function commandIndexController(
     $sce,
     localStorageService,
     DTOptionsBuilder,
-    SystemService
+    SystemService,
 ) {
   $scope.setWindowTitle('commands');
   $scope.filterHidden = false;
@@ -35,7 +35,7 @@ export default function commandIndexController(
       .withOption('autoWidth', false)
       .withOption(
           'pageLength',
-          localStorageService.get('_command_index_length') || 10
+          localStorageService.get('_command_index_length') || 10,
       )
       .withOption('hiddenContainer', true)
       .withOption('order', [
@@ -140,7 +140,7 @@ export default function commandIndexController(
           const foundSystem = SystemService.findSystem(
               $stateParams.namespace,
               $stateParams.systemName,
-              $stateParams.systemVersion
+              $stateParams.systemVersion,
           );
           if (foundSystem.template) {
             if ($scope.config.executeJavascript) {

--- a/src/ui/src/js/controllers/command_index.js
+++ b/src/ui/src/js/controllers/command_index.js
@@ -1,64 +1,66 @@
 commandIndexController.$inject = [
-  "$rootScope",
-  "$scope",
-  "$stateParams",
-  "$sce",
-  "localStorageService",
-  "DTOptionsBuilder",
-  "SystemService",
+  '$rootScope',
+  '$scope',
+  '$stateParams',
+  '$sce',
+  'localStorageService',
+  'DTOptionsBuilder',
+  'SystemService',
 ];
 
 /**
  * commandIndexController - Angular controller for all commands page.
  * @param  {Object} $rootScope       Angular's $rootScope object.
  * @param  {Object} $scope           Angular's $scope object.
+ * @param  {Object} $stateParams
  * @param  {Object} $sce             Angular's $sce object.
  * @param  {Object} localStorageService  Storage service
  * @param  {Object} DTOptionsBuilder Data-tables' builder for options.
+ * @param  {Object} SystemService
  */
 export default function commandIndexController(
-  $rootScope,
-  $scope,
-  $stateParams,
-  $sce,
-  localStorageService,
-  DTOptionsBuilder,
-  SystemService
+    $rootScope,
+    $scope,
+    $stateParams,
+    $sce,
+    localStorageService,
+    DTOptionsBuilder,
+    SystemService
 ) {
-  $scope.setWindowTitle("commands");
+  $scope.setWindowTitle('commands');
   $scope.filterHidden = false;
-  $scope.template = "";
+  $scope.template = '';
   $scope.dtInstance = {};
   $scope.dtOptions = DTOptionsBuilder.newOptions()
-    .withOption("autoWidth", false)
-    .withOption(
-      "pageLength",
-      localStorageService.get("_command_index_length") || 10
-    )
-    .withOption("hiddenContainer", true)
-    .withOption("order", [
-      [0, "asc"],
-      [1, "asc"],
-      [2, "asc"],
-      [3, "asc"],
-    ])
-    .withBootstrap();
+      .withOption('autoWidth', false)
+      .withOption(
+          'pageLength',
+          localStorageService.get('_command_index_length') || 10
+      )
+      .withOption('hiddenContainer', true)
+      .withOption('order', [
+        [0, 'asc'],
+        [1, 'asc'],
+        [2, 'asc'],
+        [3, 'asc'],
+      ])
+      .withBootstrap();
 
-  $scope.instanceCreated = function (_instance) {
+  $scope.instanceCreated = function(_instance) {
     $scope.dtInstance = _instance;
 
-    $("#commandIndexTable").on("length.dt", (event, settings, len) => {
-      localStorageService.set("_command_index_length", len);
+    $('#commandIndexTable').on('length.dt', (event, settings, len) => {
+      localStorageService.set('_command_index_length', len);
     });
   };
 
-  $scope.hiddenComparator = function (hidden, checkbox) {
+  $scope.hiddenComparator = function(hidden, checkbox) {
     return checkbox || !hidden;
   };
 
-  $scope.nodeMove = function (location) {
-    var node = document.getElementById("filterHidden");
-    var list = document.getElementById(location);
+  $scope.nodeMove = function(location) {
+    const node = document.getElementById('filterHidden');
+    const list = document.getElementById(location);
     list.append(node, list.childNodes[0]);
   };
 
@@ -71,40 +73,40 @@ export default function commandIndexController(
   ) {
     $scope.dtOptions = $scope.dtOptions.withLightColumnFilter({
       0: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Namespace Filter" },
+        html: 'input',
+        type: 'text',
+        attr: {class: 'form-inline form-control', title: 'Namespace Filter'},
       },
       1: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "System Filter" },
+        html: 'input',
+        type: 'text',
+        attr: {class: 'form-inline form-control', title: 'System Filter'},
       },
       2: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Version Filter" },
+        html: 'input',
+        type: 'text',
+        attr: {class: 'form-inline form-control', title: 'Version Filter'},
       },
       3: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Command Filter" },
+        html: 'input',
+        type: 'text',
+        attr: {class: 'form-inline form-control', title: 'Command Filter'},
       },
       4: {
-        html: "input",
-        type: "text",
+        html: 'input',
+        type: 'text',
         attr: {
-          class: "form-inline form-control",
-          title: "Description Filter",
+          class: 'form-inline form-control',
+          title: 'Description Filter',
         },
       },
     });
   }
 
-  $scope.successCallback = function (response) {
+  $scope.successCallback = function(response) {
     // Pull out what we care about
     let commands = [];
-    let breadCrumbs = [];
+    const breadCrumbs = [];
 
     response.data.forEach((system) => {
       system.commands.forEach((command) => {
@@ -115,17 +117,17 @@ export default function commandIndexController(
           name: command.name,
           system: system.display_name || system.name,
           version: system.version,
-          description: command.description || "No Description Provided",
+          description: command.description || 'No Description Provided',
         });
       });
     });
 
     if ($stateParams.namespace) {
-      commands = _.filter(commands, { namespace: $stateParams.namespace });
+      commands = _.filter(commands, {namespace: $stateParams.namespace});
       breadCrumbs.push($stateParams.namespace);
 
       if ($stateParams.systemName) {
-        commands = _.filter(commands, { system: $stateParams.systemName });
+        commands = _.filter(commands, {system: $stateParams.systemName});
         breadCrumbs.push($stateParams.systemName);
 
         if ($stateParams.systemVersion) {
@@ -135,10 +137,10 @@ export default function commandIndexController(
           breadCrumbs.push($stateParams.systemVersion);
 
           // If there's a fully specified system and it has a template, show it
-          let foundSystem = SystemService.findSystem(
-            $stateParams.namespace,
-            $stateParams.systemName,
-            $stateParams.systemVersion
+          const foundSystem = SystemService.findSystem(
+              $stateParams.namespace,
+              $stateParams.systemName,
+              $stateParams.systemVersion
           );
           if (foundSystem.template) {
             if ($scope.config.executeJavascript) {
@@ -155,15 +157,15 @@ export default function commandIndexController(
     $scope.data = commands;
     $scope.dtOptions.withLanguage({
       info:
-        "Showing _START_ to _END_ of _TOTAL_ entries (filtered from " +
+        'Showing _START_ to _END_ of _TOTAL_ entries (filtered from ' +
         $scope.data.length +
-        " total entries)",
-      infoFiltered: "",
+        ' total entries)',
+      infoFiltered: '',
     });
     $scope.breadCrumbs = breadCrumbs;
   };
 
-  $scope.failureCallback = function (response) {
+  $scope.failureCallback = function(response) {
     $scope.response = response;
     $scope.data = {};
   };

--- a/src/ui/src/js/controllers/command_view.js
+++ b/src/ui/src/js/controllers/command_view.js
@@ -37,7 +37,7 @@ export default function commandViewController(
     RequestService,
     SFBuilderService,
     system,
-    command
+    command,
 ) {
   let tempResponse = $rootScope.sysResponse;
 
@@ -131,7 +131,7 @@ export default function commandViewController(
       $scope.createRequest(model);
     } else {
       $scope.alerts.push(
-          'Looks like there was an error validating the request.'
+          'Looks like there was an error validating the request.',
       );
     }
   };
@@ -167,7 +167,7 @@ export default function commandViewController(
         }
         fd.append(
             $scope.command.parameters[i].key,
-            document.getElementById($scope.command.parameters[i].key).files[0]
+            document.getElementById($scope.command.parameters[i].key).files[0],
         );
       }
     }
@@ -182,7 +182,7 @@ export default function commandViewController(
         },
         function(response) {
           $scope.createResponse = response;
-        }
+        },
     );
   };
 
@@ -257,7 +257,7 @@ export default function commandViewController(
         $scope.command.name,
         $scope.system.display_name || $scope.system.name,
         $scope.system.version,
-        'command'
+        'command',
     );
   };
 
@@ -283,7 +283,7 @@ export default function commandViewController(
           }
         }
       },
-      true
+      true,
   );
 
   // This process of stringify / parse will break the optional model
@@ -309,7 +309,7 @@ export default function commandViewController(
             }
           }
         },
-        true
+        true,
     );
   }
 

--- a/src/ui/src/js/controllers/command_view.js
+++ b/src/ui/src/js/controllers/command_view.js
@@ -1,17 +1,17 @@
-import angular from "angular";
-import { formatJsonDisplay } from "../services/utility_service.js";
+import angular from 'angular';
+import {formatJsonDisplay} from '../services/utility_service.js';
 
 commandViewController.$inject = [
-  "$rootScope",
-  "$scope",
-  "$state",
-  "$stateParams",
-  "$sce",
-  "$q",
-  "RequestService",
-  "SFBuilderService",
-  "system",
-  "command",
+  '$rootScope',
+  '$scope',
+  '$state',
+  '$stateParams',
+  '$sce',
+  '$q',
+  'RequestService',
+  'SFBuilderService',
+  'system',
+  'command',
 ];
 
 /**
@@ -24,18 +24,20 @@ commandViewController.$inject = [
  * @param  {Object} $q                Angular's $q object.
  * @param  {Object} RequestService    Beer-Garden's request service object.
  * @param  {Object} SFBuilderService  Beer-Garden's schema-form builder service object.
+ * @param  {Object} system            System
+ * @param  {Object} command           Command
  */
 export default function commandViewController(
-  $rootScope,
-  $scope,
-  $state,
-  $stateParams,
-  $sce,
-  $q,
-  RequestService,
-  SFBuilderService,
-  system,
-  command
+    $rootScope,
+    $scope,
+    $state,
+    $stateParams,
+    $sce,
+    $q,
+    RequestService,
+    SFBuilderService,
+    system,
+    command
 ) {
   let tempResponse = $rootScope.sysResponse;
 
@@ -44,28 +46,28 @@ export default function commandViewController(
   $scope.model = $stateParams.request || {};
   $scope.alerts = [];
   $scope.baseModel = {};
-  $scope.template = "";
+  $scope.template = '';
   $scope.manualOverride = false;
-  $scope.manualModel = "";
+  $scope.manualModel = '';
 
   $scope.system = system;
 
   $scope.jsonValues = {
-    model: "",
-    command: "",
-    schema: "",
-    form: "",
+    model: '',
+    command: '',
+    schema: '',
+    form: '',
   };
 
-  $scope.createRequestWrapper = function (requestPrototype, ...args) {
-    let request = {
-      command: requestPrototype["command"],
-      namespace: requestPrototype["namespace"] || $scope.system.namespace,
-      system: requestPrototype["system"] || $scope.system.name,
+  $scope.createRequestWrapper = function(requestPrototype, ...args) {
+    const request = {
+      command: requestPrototype['command'],
+      namespace: requestPrototype['namespace'] || $scope.system.namespace,
+      system: requestPrototype['system'] || $scope.system.name,
       system_version:
-        requestPrototype["system_version"] || $scope.system.version,
+        requestPrototype['system_version'] || $scope.system.version,
       instance_name:
-        requestPrototype["instance_name"] || $scope.model["instance_name"],
+        requestPrototype['instance_name'] || $scope.model['instance_name'],
     };
 
     // If a system has more than one instance this will be undefined on initial page
@@ -73,25 +75,25 @@ export default function commandViewController(
     // an error like "Could not find instance with name 'None' in system". That's not
     // the best, so this special handling makes the error message a little nicer.
     if (!request.instance_name) {
-      let deferred = $q.defer();
-      deferred.reject("Please select an instance");
+      const deferred = $q.defer();
+      deferred.reject('Please select an instance');
       return deferred.promise;
     }
 
     // If parameters are specified we need to use the model value
-    if (angular.isDefined(requestPrototype["parameterNames"])) {
-      request["parameters"] = {};
-      let nameList = requestPrototype["parameterNames"];
+    if (angular.isDefined(requestPrototype['parameterNames'])) {
+      request['parameters'] = {};
+      const nameList = requestPrototype['parameterNames'];
       for (let i = 0; i < nameList.length; i++) {
-        request["parameters"][nameList[i]] = args[i];
+        request['parameters'][nameList[i]] = args[i];
       }
     }
 
     return RequestService.createRequest(request, true);
   };
 
-  $scope.checkInstance = function () {
-    let instance = _.find($scope.system.instances, {
+  $scope.checkInstance = function() {
+    const instance = _.find($scope.system.instances, {
       name: $scope.model.instance_name,
     });
 
@@ -99,25 +101,25 @@ export default function commandViewController(
       return false;
     }
 
-    return instance.status != "RUNNING";
+    return instance.status != 'RUNNING';
   };
 
-  $scope.submitForm = function (form, model) {
+  $scope.submitForm = function(form, model) {
     // Remove all the old alerts so they don't just stack up
     $scope.alerts.splice(0);
 
     // Give all the fields the chance to validate
-    $scope.$broadcast("schemaFormValidate");
+    $scope.$broadcast('schemaFormValidate');
 
     // This is gross, but tv4 does not handle arrays well and throws errors
     // where it shouldn't. I don't think it's possible to fix without a patch
     // to tv4 or ASF so for now just ignore the false positive.
     let valid = true;
     if (!form.$valid) {
-      angular.forEach(form.$error, function (errorGroup, errorKey) {
-        if (errorKey !== "schemaForm") {
-          angular.forEach(errorGroup, function (error) {
-            if (errorKey !== "tv4-0" || !Array.isArray(error.$modelValue)) {
+      angular.forEach(form.$error, function(errorGroup, errorKey) {
+        if (errorKey !== 'schemaForm') {
+          angular.forEach(errorGroup, function(error) {
+            if (errorKey !== 'tv4-0' || !Array.isArray(error.$modelValue)) {
               valid = false;
             }
           });
@@ -129,13 +131,13 @@ export default function commandViewController(
       $scope.createRequest(model);
     } else {
       $scope.alerts.push(
-        "Looks like there was an error validating the request."
+          'Looks like there was an error validating the request.'
       );
     }
   };
 
-  $scope.createRequest = function (request) {
-    if (typeof request === "string") {
+  $scope.createRequest = function(request) {
+    if (typeof request === 'string') {
       try {
         request = JSON.parse(request);
       } catch (err) {
@@ -146,21 +148,21 @@ export default function commandViewController(
     let newRequest = angular.copy(request);
 
     if (
-      $scope.system["display_name"] &&
-      $scope.system["display_name"] === newRequest["system"]
+      $scope.system['display_name'] &&
+      $scope.system['display_name'] === newRequest['system']
     ) {
-      newRequest["system"] = $scope.system["name"];
-      newRequest["metadata"] = {
-        system_display_name: $scope.system["display_name"],
+      newRequest['system'] = $scope.system['name'];
+      newRequest['metadata'] = {
+        system_display_name: $scope.system['display_name'],
       };
     }
 
     let isFormData = false;
     const fd = new FormData();
     for (const i in $scope.command.parameters) {
-      if ($scope.command.parameters[i].type.toLowerCase() === "bytes") {
+      if ($scope.command.parameters[i].type.toLowerCase() === 'bytes') {
         if (!isFormData) {
-          fd.append("request", JSON.stringify(newRequest));
+          fd.append('request', JSON.stringify(newRequest));
           isFormData = true;
         }
         fd.append(
@@ -175,16 +177,16 @@ export default function commandViewController(
     }
 
     RequestService.createRequest(newRequest, false, isFormData).then(
-      function (response) {
-        $state.go("base.request", { requestId: response.data.id });
-      },
-      function (response) {
-        $scope.createResponse = response;
-      }
+        function(response) {
+          $state.go('base.request', {requestId: response.data.id});
+        },
+        function(response) {
+          $scope.createResponse = response;
+        }
     );
   };
 
-  $scope.reset = function (form, model, system, command) {
+  $scope.reset = function(form, model, system, command) {
     $scope.createResponse = undefined;
     $scope.alerts.splice(0);
     $scope.model = {};
@@ -193,40 +195,40 @@ export default function commandViewController(
     form.$setPristine();
   };
 
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
-  $scope.loadPreview = function (_editor) {
+  $scope.loadPreview = function(_editor) {
     formatJsonDisplay(_editor, true);
   };
 
-  $scope.loadEditor = function (_editor) {
+  $scope.loadEditor = function(_editor) {
     formatJsonDisplay(_editor, false);
   };
 
-  $scope.toggleManualOverride = function () {
+  $scope.toggleManualOverride = function() {
     $scope.alerts.splice(0);
     $scope.createResponse = undefined;
     $scope.manualOverride = !$scope.manualOverride;
     $scope.manualModel = $scope.jsonValues.model;
   };
 
-  $scope.scheduleRequest = function () {
-    $state.go("base.jobscreatetrigger", { request: $scope.model });
+  $scope.scheduleRequest = function() {
+    $state.go('base.jobscreatetrigger', {request: $scope.model});
   };
 
-  let generateSF = function () {
-    let sf = SFBuilderService.build($scope.system, $scope.command);
+  const generateSF = function() {
+    const sf = SFBuilderService.build($scope.system, $scope.command);
 
-    $scope.schema = sf["schema"];
-    $scope.form = sf["form"];
+    $scope.schema = sf['schema'];
+    $scope.form = sf['form'];
 
     $scope.jsonValues.schema = JSON.stringify($scope.schema, undefined, 2);
     $scope.jsonValues.form = JSON.stringify($scope.form, undefined, 2);
   };
 
-  $scope.successCallback = function (command) {
+  $scope.successCallback = function(command) {
     $scope.command = command;
     $scope.jsonValues.command = JSON.stringify($scope.command, undefined, 2);
 
@@ -252,14 +254,14 @@ export default function commandViewController(
     ];
 
     $scope.setWindowTitle(
-      $scope.command.name,
-      $scope.system.display_name || $scope.system.name,
-      $scope.system.version,
-      "command"
+        $scope.command.name,
+        $scope.system.display_name || $scope.system.name,
+        $scope.system.version,
+        'command'
     );
   };
 
-  $scope.failureCallback = function (response) {
+  $scope.failureCallback = function(response) {
     tempResponse = response;
     $scope.response = response;
     $scope.command = [];
@@ -267,55 +269,55 @@ export default function commandViewController(
   };
 
   $scope.$watch(
-    "model",
-    function (val, old) {
-      if (val && val !== old) {
-        if ($scope.system["display_name"]) {
-          val["system"] = $scope.system["display_name"];
-        }
+      'model',
+      function(val, old) {
+        if (val && val !== old) {
+          if ($scope.system['display_name']) {
+            val['system'] = $scope.system['display_name'];
+          }
 
-        try {
-          $scope.jsonValues.model = angular.toJson(val, 2);
-        } catch (e) {
-          console.error("Error attempting to stringify the model");
+          try {
+            $scope.jsonValues.model = angular.toJson(val, 2);
+          } catch (e) {
+            console.error('Error attempting to stringify the model');
+          }
         }
-      }
-    },
-    true
+      },
+      true
   );
 
   // This process of stringify / parse will break the optional model
   // functionality. It's only useful in dev mode so only enable it then
   if ($scope.config.debugMode === true) {
     $scope.$watch(
-      "jsonValues",
-      function (val, old) {
-        if (val && old) {
-          if (val.schema !== old.schema) {
-            try {
-              $scope.schema = JSON.parse(val.schema);
-            } catch (e) {
-              console.log("schema doesn't parse");
+        'jsonValues',
+        function(val, old) {
+          if (val && old) {
+            if (val.schema !== old.schema) {
+              try {
+                $scope.schema = JSON.parse(val.schema);
+              } catch (e) {
+                console.log('schema doesn\'t parse');
+              }
+            }
+            if (val.form !== old.form) {
+              try {
+                $scope.form = JSON.parse(val.form);
+              } catch (e) {
+                console.log('form doesn\'t parse');
+              }
             }
           }
-          if (val.form !== old.form) {
-            try {
-              $scope.form = JSON.parse(val.form);
-            } catch (e) {
-              console.log("form doesn't parse");
-            }
-          }
-        }
-      },
-      true
+        },
+        true
     );
   }
 
   // Model instantiate button will emit this so need to listen for it
-  $scope.$on("generateSF", generateSF);
+  $scope.$on('generateSF', generateSF);
 
   // Stop the loading animation after the schema form is done
-  $scope.$on("sf-render-finished", () => {
+  $scope.$on('sf-render-finished', () => {
     $scope.response = tempResponse;
   });
 

--- a/src/ui/src/js/controllers/garden/export_garden_config.js
+++ b/src/ui/src/js/controllers/garden/export_garden_config.js
@@ -1,0 +1,51 @@
+gardenConfigExportController.$inject =
+    ['$scope', '$rootScope', '$filter', 'GardenService'];
+
+/**
+ * gardenConfigExportController - Controller for the garden config export page.
+ * @param  {Object} $scope            Angular's $scope object.
+ * @param  {Object} $rootScope        Angular's $rootScope object.
+ * @param  {Object} $filter           Filter
+ * @param  {Object} GardenService     Beer-Garden's garden service.
+ */
+export default function gardenConfigExportController(
+    $scope,
+    $rootScope,
+    $filter,
+    GardenService,
+) {
+  $scope.response = $rootScope.sysResponse;
+
+  $scope.exportGardenConfig = (gardenName) => {
+    const filename =
+      `GardenExport_${gardenName}_` +
+      $filter('date')(new Date(Date.now()), 'yyyyMMdd_HHmmss');
+
+    const formModel = GardenService.formToServerModel($scope.data, $scope.gardenModel);
+
+    const [newConnectionInfo, newConnectionParams] = [{}, {}];
+    newConnectionInfo['connection_type'] = formModel['connection_type'];
+
+    if (formModel['connection_params']['http']) {
+      newConnectionParams['http'] = formModel['connection_params']['http'];
+    }
+
+    if (formModel['connection_params']['stomp']) {
+      newConnectionParams['stomp'] = formModel['connection_params']['stomp'];
+    }
+
+    newConnectionInfo['connection_params'] = newConnectionParams;
+
+    const blob = new Blob(
+        [JSON.stringify(newConnectionInfo)],
+        {
+          type: 'application/json;charset=utf-8',
+        },
+    );
+    const downloadLink = angular.element('<a></a>');
+
+    downloadLink.attr('href', window.URL.createObjectURL(blob));
+    downloadLink.attr('download', filename);
+    downloadLink[0].click();
+  };
+}

--- a/src/ui/src/js/controllers/garden/import_garden_config.js
+++ b/src/ui/src/js/controllers/garden/import_garden_config.js
@@ -1,0 +1,101 @@
+import template from '../../../templates/import_garden_config.html';
+
+gardenConfigImportController.$inject = [
+  '$scope',
+  '$rootScope',
+  '$uibModal',
+  '$state',
+];
+
+/**
+ * gardenConfigImportController - Controller for garden config import.
+ * @param  {Object} $scope                     Angular's $scope object.
+ * @param  {Object} $rootScope                 Angular's $rootScope object.
+ * @param  {Object} $uibModal                  Angular UI's $uibModal object.
+ * @param  {Object} $state                     State
+ */
+export function gardenConfigImportController(
+    $scope,
+    $rootScope,
+    $uibModal,
+    $state,
+) {
+  $scope.response = $rootScope.sysResponse;
+
+  $scope.openImportGardenConfigPopup = () => {
+    const popupInstance = $uibModal.open({
+      animation: true,
+      controller: 'GardenConfigImportModalController',
+      template: template,
+    });
+
+    popupInstance.result.then((resolvedResponse) => {
+      const jsonFileContents = resolvedResponse.jsonFileContents;
+      const newConfig = JSON.parse(jsonFileContents);
+
+      $scope.updateModelFromImport(newConfig);
+    }, angular.noop);
+  };
+}
+
+gardenConfigImportModalController.$inject =
+    ['$scope', '$window', '$uibModalInstance'];
+
+/**
+ * gardenConfigImportModalController - Controller for the garden config import
+ * popup window.
+ *
+ * @param {Object} $scope Angular's $scope object.
+ * @param {Object} $window Object for the browser window.
+ * @param {Object} $uibModalInstance Object for the modal popup window.
+ */
+export function gardenConfigImportModalController(
+    $scope, $window, $uibModalInstance) {
+  $scope.import = {};
+  $scope.fileName = undefined;
+  $scope.fileContents = undefined;
+  $scope.fileIsGoodJson = true;
+
+  $scope.inputClicker = function() {
+    $window.document.getElementById('fileSelectHiddenControl').click();
+  };
+
+  $scope.doImport = function() {
+    $scope.import['jsonFileContents'] = $scope.fileContents;
+    $uibModalInstance.close($scope.import);
+  };
+
+  $scope.cancelImport = function() {
+    $uibModalInstance.dismiss('cancel');
+  };
+
+  function isParsableJson(string) {
+    try {
+      JSON.parse(string);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  }
+
+  $scope.onFileSelected = function(event) {
+    const theFile = event.target.files[0];
+    $scope.fileName = theFile.name;
+
+    const reader = new FileReader();
+    reader.onload = function(e) {
+      $scope.$apply(function() {
+        const result = reader.result;
+        const isGoodJson = isParsableJson(result);
+
+        if (isGoodJson) {
+          $scope.fileContents = result;
+          $scope.fileIsGoodJson = true;
+        } else {
+          $scope.fileIsGoodJson = false;
+        }
+      });
+    };
+    reader.readAsText(theFile);
+  };
+}

--- a/src/ui/src/js/controllers/job/create_command.js
+++ b/src/ui/src/js/controllers/job/create_command.js
@@ -1,4 +1,4 @@
-jobCreateCommandController.$inject = ["$scope", "$stateParams"];
+jobCreateCommandController.$inject = ['$scope', '$stateParams'];
 
 /**
  * jobCreateController - Controller for the job create page.
@@ -6,7 +6,7 @@ jobCreateCommandController.$inject = ["$scope", "$stateParams"];
  * @param  {Object} $stateParams      Angular's $stateParams object.
  */
 export default function jobCreateCommandController($scope, $stateParams) {
-  $scope.setWindowTitle("scheduler");
+  $scope.setWindowTitle('scheduler');
 
   $scope.system = $stateParams.system;
 }

--- a/src/ui/src/js/controllers/job/create_request.js
+++ b/src/ui/src/js/controllers/job/create_request.js
@@ -1,11 +1,11 @@
-import { formatJsonDisplay } from "../../services/utility_service.js";
+import {formatJsonDisplay} from '../../services/utility_service.js';
 
 jobCreateRequestController.$inject = [
-  "$scope",
-  "$state",
-  "$stateParams",
-  "SFBuilderService",
-  "SystemService",
+  '$scope',
+  '$state',
+  '$stateParams',
+  'SFBuilderService',
+  'SystemService',
 ];
 
 /**
@@ -17,13 +17,13 @@ jobCreateRequestController.$inject = [
  * @param  {Object} SystemService   Beer-Garden's system service object.
  */
 export default function jobCreateRequestController(
-  $scope,
-  $state,
-  $stateParams,
-  SFBuilderService,
-  SystemService
+    $scope,
+    $state,
+    $stateParams,
+    SFBuilderService,
+    SystemService
 ) {
-  $scope.setWindowTitle("scheduler");
+  $scope.setWindowTitle('scheduler');
 
   $scope.alerts = [];
 
@@ -37,12 +37,12 @@ export default function jobCreateRequestController(
     $scope.command = $stateParams.command;
   } else {
     $scope.system = SystemService.findSystem(
-      $stateParams.job.request_template.namespace,
-      $stateParams.job.request_template.system,
-      $stateParams.job.request_template.system_version
+        $stateParams.job.request_template.namespace,
+        $stateParams.job.request_template.system,
+        $stateParams.job.request_template.system_version
     );
 
-    for (let i in $scope.system.commands) {
+    for (const i in $scope.system.commands) {
       if (
         $scope.system.commands[i].name ==
         $stateParams.job.request_template.command
@@ -54,62 +54,62 @@ export default function jobCreateRequestController(
 
     $scope.job = $stateParams.job;
 
-    //Clone to allow resets
+    // Clone to allow resets
     $scope.model = _.cloneDeep($scope.job.request_template);
     $scope.modelJson = angular.toJson($scope.model, 2);
   }
 
-  let generateRequestSF = function () {
-    let sf = SFBuilderService.build($scope.system, $scope.command);
+  const generateRequestSF = function() {
+    const sf = SFBuilderService.build($scope.system, $scope.command);
 
-    $scope.schema = sf["schema"];
-    $scope.form = sf["form"];
+    $scope.schema = sf['schema'];
+    $scope.form = sf['form'];
 
-    $scope.$broadcast("schemaFormRedraw");
+    $scope.$broadcast('schemaFormRedraw');
   };
 
   // These are shared with create_trigger
-  $scope.loadPreview = function (_editor) {
+  $scope.loadPreview = function(_editor) {
     formatJsonDisplay(_editor, true);
   };
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
   $scope.$watch(
-    "model",
-    function (val, old) {
-      if (val && val !== old) {
-        if ($scope.system["display_name"]) {
-          val["system"] = $scope.system["display_name"];
-        }
+      'model',
+      function(val, old) {
+        if (val && val !== old) {
+          if ($scope.system['display_name']) {
+            val['system'] = $scope.system['display_name'];
+          }
 
-        try {
-          $scope.modelJson = angular.toJson(val, 2);
-        } catch (e) {
-          console.error("Error attempting to stringify the model");
+          try {
+            $scope.modelJson = angular.toJson(val, 2);
+          } catch (e) {
+            console.error('Error attempting to stringify the model');
+          }
         }
-      }
-    },
-    true
+      },
+      true
   );
 
-  $scope.submit = function (form, model) {
+  $scope.submit = function(form, model) {
     // Remove all the old alerts so they don't just stack up
     $scope.alerts.splice(0);
 
     // Give all the fields the chance to validate
-    $scope.$broadcast("schemaFormValidate");
+    $scope.$broadcast('schemaFormValidate');
 
     // This is gross, but tv4 does not handle arrays well and throws errors
     // where it shouldn't. I don't think it's possible to fix without a patch
     // to tv4 or ASF so for now just ignore the false positive.
     let valid = true;
     if (!form.$valid) {
-      angular.forEach(form.$error, function (errorGroup, errorKey) {
-        if (errorKey !== "schemaForm") {
-          angular.forEach(errorGroup, function (error) {
-            if (errorKey !== "tv4-0" || !Array.isArray(error.$modelValue)) {
+      angular.forEach(form.$error, function(errorGroup, errorKey) {
+        if (errorKey !== 'schemaForm') {
+          angular.forEach(errorGroup, function(error) {
+            if (errorKey !== 'tv4-0' || !Array.isArray(error.$modelValue)) {
               valid = false;
             }
           });
@@ -118,30 +118,30 @@ export default function jobCreateRequestController(
     }
 
     if (valid) {
-      let newRequest = angular.copy($scope.model);
+      const newRequest = angular.copy($scope.model);
 
       if (
-        $scope.system["display_name"] &&
-        $scope.system["display_name"] === newRequest["system"]
+        $scope.system['display_name'] &&
+        $scope.system['display_name'] === newRequest['system']
       ) {
-        newRequest["system"] = $scope.system["name"];
-        newRequest["metadata"] = {
-          system_display_name: $scope.system["display_name"],
+        newRequest['system'] = $scope.system['name'];
+        newRequest['metadata'] = {
+          system_display_name: $scope.system['display_name'],
         };
       }
 
-      $state.go("base.jobscreatetrigger", {
+      $state.go('base.jobscreatetrigger', {
         job: $scope.job,
         request: newRequest,
       });
     } else {
       $scope.alerts.push(
-        "Looks like there was an error validating the request."
+          'Looks like there was an error validating the request.'
       );
     }
   };
 
-  $scope.reset = function (form, model, system, command) {
+  $scope.reset = function(form, model, system, command) {
     $scope.alerts.splice(0);
 
     if ($scope.job == null) {

--- a/src/ui/src/js/controllers/job/create_request.js
+++ b/src/ui/src/js/controllers/job/create_request.js
@@ -21,7 +21,7 @@ export default function jobCreateRequestController(
     $state,
     $stateParams,
     SFBuilderService,
-    SystemService
+    SystemService,
 ) {
   $scope.setWindowTitle('scheduler');
 
@@ -39,7 +39,7 @@ export default function jobCreateRequestController(
     $scope.system = SystemService.findSystem(
         $stateParams.job.request_template.namespace,
         $stateParams.job.request_template.system,
-        $stateParams.job.request_template.system_version
+        $stateParams.job.request_template.system_version,
     );
 
     for (const i in $scope.system.commands) {
@@ -91,7 +91,7 @@ export default function jobCreateRequestController(
           }
         }
       },
-      true
+      true,
   );
 
   $scope.submit = function(form, model) {
@@ -136,7 +136,7 @@ export default function jobCreateRequestController(
       });
     } else {
       $scope.alerts.push(
-          'Looks like there was an error validating the request.'
+          'Looks like there was an error validating the request.',
       );
     }
   };

--- a/src/ui/src/js/controllers/job/create_system.js
+++ b/src/ui/src/js/controllers/job/create_system.js
@@ -1,4 +1,4 @@
-jobCreateSystemController.$inject = ["$scope", "$rootScope"];
+jobCreateSystemController.$inject = ['$scope', '$rootScope'];
 
 /**
  * jobCreateController - Controller for the job create page.
@@ -6,7 +6,7 @@ jobCreateSystemController.$inject = ["$scope", "$rootScope"];
  * @param  {Object} $rootScope        Angular's $rootScope object.
  */
 export default function jobCreateSystemController($scope, $rootScope) {
-  $scope.setWindowTitle("scheduler");
+  $scope.setWindowTitle('scheduler');
 
   $scope.response = $rootScope.sysResponse;
   $scope.data = $rootScope.systems;

--- a/src/ui/src/js/controllers/job/create_trigger.js
+++ b/src/ui/src/js/controllers/job/create_trigger.js
@@ -18,7 +18,7 @@ export default function jobCreateTriggerController(
     $scope,
     $state,
     $stateParams,
-    JobService
+    JobService,
 ) {
   $scope.setWindowTitle('scheduler');
 
@@ -62,7 +62,7 @@ export default function jobCreateTriggerController(
           model['interval_timezone'] === null)
       ) {
         $scope.alerts.push(
-            'If a date is specified, you must specify the timezone.'
+            'If a date is specified, you must specify the timezone.',
         );
         valid = false;
       }
@@ -78,7 +78,7 @@ export default function jobCreateTriggerController(
           model['cron_timezone'] === null)
       ) {
         $scope.alerts.push(
-            'If a date is specified, you must specify the timezone.'
+            'If a date is specified, you must specify the timezone.',
         );
         valid = false;
       }
@@ -129,7 +129,7 @@ export default function jobCreateTriggerController(
           }
         }
       },
-      true
+      true,
   );
 
   $scope.submit = function(form, model) {
@@ -148,11 +148,11 @@ export default function jobCreateTriggerController(
           },
           function(response) {
             $scope.createResponse = response;
-          }
+          },
       );
     } else {
       $scope.alerts.push(
-          'Looks like there was an error validating the request.'
+          'Looks like there was an error validating the request.',
       );
     }
   };

--- a/src/ui/src/js/controllers/job/create_trigger.js
+++ b/src/ui/src/js/controllers/job/create_trigger.js
@@ -1,10 +1,10 @@
-import { formatJsonDisplay } from "../../services/utility_service.js";
+import {formatJsonDisplay} from '../../services/utility_service.js';
 
 jobCreateTriggerController.$inject = [
-  "$scope",
-  "$state",
-  "$stateParams",
-  "JobService",
+  '$scope',
+  '$state',
+  '$stateParams',
+  'JobService',
 ];
 
 /**
@@ -15,12 +15,12 @@ jobCreateTriggerController.$inject = [
  * @param  {Object} JobService        Beer-Garden's job service.
  */
 export default function jobCreateTriggerController(
-  $scope,
-  $state,
-  $stateParams,
-  JobService
+    $scope,
+    $state,
+    $stateParams,
+    JobService
 ) {
-  $scope.setWindowTitle("scheduler");
+  $scope.setWindowTitle('scheduler');
 
   $scope.alerts = [];
 
@@ -34,74 +34,74 @@ export default function jobCreateTriggerController(
     $scope.model = JobService.serverModelToForm($stateParams.job);
   }
 
-  let generateJobSF = function () {
-    $scope.$broadcast("schemaFormRedraw");
+  const generateJobSF = function() {
+    $scope.$broadcast('schemaFormRedraw');
   };
 
-  const extraValidate = function (model) {
-    let triggerType = model["trigger_type"];
+  const extraValidate = function(model) {
+    const triggerType = model['trigger_type'];
     let valid = true;
     if (!angular.isDefined(triggerType) || triggerType === null) {
       return false;
     }
 
-    for (let key of JobService.getRequiredKeys(triggerType)) {
+    for (const key of JobService.getRequiredKeys(triggerType)) {
       if (!angular.isDefined(model[key]) || model[key] === null) {
-        $scope.alerts.push("Missing required key: " + key);
+        $scope.alerts.push('Missing required key: ' + key);
         valid = false;
       }
     }
 
-    if (triggerType === "interval") {
+    if (triggerType === 'interval') {
       if (
-        ((angular.isDefined(model["interval_start_date"]) &&
-          model["interval_start_date"] !== null) ||
-          (angular.isDefined(model["interval_end_date"]) &&
-            model["interval_end_date"] !== null)) &&
-        (!angular.isDefined(model["interval_timezone"]) ||
-          model["interval_timezone"] === null)
+        ((angular.isDefined(model['interval_start_date']) &&
+          model['interval_start_date'] !== null) ||
+          (angular.isDefined(model['interval_end_date']) &&
+            model['interval_end_date'] !== null)) &&
+        (!angular.isDefined(model['interval_timezone']) ||
+          model['interval_timezone'] === null)
       ) {
         $scope.alerts.push(
-          "If a date is specified, you must specify the timezone."
+            'If a date is specified, you must specify the timezone.'
         );
         valid = false;
       }
     }
 
-    if (triggerType === "cron") {
+    if (triggerType === 'cron') {
       if (
-        ((angular.isDefined(model["cron_start_date"]) &&
-          model["cron_start_date"] !== null) ||
-          (angular.isDefined(model["cron_end_date"]) &&
-            model["cron_end_date"] !== null)) &&
-        (!angular.isDefined(model["cron_timezone"]) ||
-          model["cron_timezone"] === null)
+        ((angular.isDefined(model['cron_start_date']) &&
+          model['cron_start_date'] !== null) ||
+          (angular.isDefined(model['cron_end_date']) &&
+            model['cron_end_date'] !== null)) &&
+        (!angular.isDefined(model['cron_timezone']) ||
+          model['cron_timezone'] === null)
       ) {
         $scope.alerts.push(
-          "If a date is specified, you must specify the timezone."
+            'If a date is specified, you must specify the timezone.'
         );
         valid = false;
       }
     }
 
-    if (triggerType === "file") {
+    if (triggerType === 'file') {
       if (
-        angular.isDefined(model["file_pattern"]) &&
-        model["file_pattern"] === [""]
+        angular.isDefined(model['file_pattern']) &&
+        model['file_pattern'] === ['']
       ) {
-        $scope.alerts.push("At least one pattern is required.");
+        $scope.alerts.push('At least one pattern is required.');
         valid = false;
       }
       if (
-        angular.isDefined(model["file_callbacks"]) &&
-        model["file_callbacks"] !== null
+        angular.isDefined(model['file_callbacks']) &&
+        model['file_callbacks'] !== null
       ) {
-        var temp = false;
-        for (var k in model["file_callbacks"]) {
-          if (model["file_callbacks"][k] == true) temp = true;
+        let temp = false;
+        for (const k in model['file_callbacks']) {
+          if (model['file_callbacks'][k] == true) temp = true;
         }
         if (!temp) {
-          $scope.alerts.push("At least one callback is required.");
+          $scope.alerts.push('At least one callback is required.');
           valid = temp;
         }
       }
@@ -111,53 +111,53 @@ export default function jobCreateTriggerController(
   };
 
   // These are shared with create_request
-  $scope.loadPreview = function (_editor) {
+  $scope.loadPreview = function(_editor) {
     formatJsonDisplay(_editor, true);
   };
-  $scope.closeAlert = function (index) {
+  $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
 
   $scope.$watch(
-    "model",
-    function (val, old) {
-      if (val && val !== old) {
-        try {
-          $scope.modelJson = angular.toJson(val, 2);
-        } catch (e) {
-          console.error("Error attempting to stringify the model");
+      'model',
+      function(val, old) {
+        if (val && val !== old) {
+          try {
+            $scope.modelJson = angular.toJson(val, 2);
+          } catch (e) {
+            console.error('Error attempting to stringify the model');
+          }
         }
-      }
-    },
-    true
+      },
+      true
   );
 
-  $scope.submit = function (form, model) {
+  $scope.submit = function(form, model) {
     $scope.alerts.splice(0);
 
-    $scope.$broadcast("schemaFormValidate");
+    $scope.$broadcast('schemaFormValidate');
 
-    let valid = extraValidate(model);
+    const valid = extraValidate(model);
 
     if (form.$valid && valid) {
-      let serverModel = JobService.formToServerModel(model, $scope.request);
+      const serverModel = JobService.formToServerModel(model, $scope.request);
 
       JobService.createJob(serverModel).then(
-        function (response) {
-          $state.go("base.job", { id: response.data.id });
-        },
-        function (response) {
-          $scope.createResponse = response;
-        }
+          function(response) {
+            $state.go('base.job', {id: response.data.id});
+          },
+          function(response) {
+            $scope.createResponse = response;
+          }
       );
     } else {
       $scope.alerts.push(
-        "Looks like there was an error validating the request."
+          'Looks like there was an error validating the request.'
       );
     }
   };
 
-  $scope.reset = function (form, model, system, command) {
+  $scope.reset = function(form, model, system, command) {
     $scope.createResponse = undefined;
     $scope.alerts.splice(0);
     if ($stateParams.job == null) {

--- a/src/ui/src/js/controllers/job/export_jobs.js
+++ b/src/ui/src/js/controllers/job/export_jobs.js
@@ -11,7 +11,7 @@ export default function jobExportController(
     $scope,
     $rootScope,
     $filter,
-    JobService
+    JobService,
 ) {
   $scope.response = $rootScope.sysResponse;
   $scope.data = $rootScope.systems;
@@ -30,7 +30,7 @@ export default function jobExportController(
           downloadLink.attr('download', filename);
           downloadLink[0].click();
         },
-        () => alert('Aborting: No Jobs defined or unknown error.')
+        () => alert('Aborting: No Jobs defined or unknown error.'),
     );
   };
 }

--- a/src/ui/src/js/controllers/job/export_jobs.js
+++ b/src/ui/src/js/controllers/job/export_jobs.js
@@ -1,50 +1,36 @@
-jobExportController.$inject = ["$scope", "$rootScope", "$filter", "JobService"];
+jobExportController.$inject = ['$scope', '$rootScope', '$filter', 'JobService'];
 
 /**
  * jobExportController - Controller for the job export page.
  * @param  {Object} $scope            Angular's $scope object.
  * @param  {Object} $rootScope        Angular's $rootScope object.
+ * @param  {Object} $filter           Filter
  * @param  {Object} JobService        Beer-Garden's job service.
  */
 export default function jobExportController(
-  $scope,
-  $rootScope,
-  $filter,
-  JobService
+    $scope,
+    $rootScope,
+    $filter,
+    JobService
 ) {
   $scope.response = $rootScope.sysResponse;
   $scope.data = $rootScope.systems;
 
-  function getFilename() {
-    let currentDate = new Date(Date.now());
-    let fmt = function (nbr) {
-      return (nbr < 10 ? "0" : "") + nbr.toString();
-    };
-    let year = currentDate.getUTCFullYear().toString(),
-      month = fmt(currentDate.getUTCMonth() + 1),
-      day = fmt(currentDate.getUTCDate()),
-      hour = fmt(currentDate.getUTCHours()),
-      minutes = fmt(currentDate.getUTCMinutes()),
-      seconds = fmt(currentDate.getUTCSeconds());
-
-    return "JobExport_" + year + month + day + "_" + hour + minutes + seconds;
-  }
-
-  $scope.exportAllJobs = function () {
+  $scope.exportAllJobs = function() {
     JobService.exportJobs().then(
-      function (response) {
-        let filename =
-          "JobExport_" +
-          $filter("date")(new Date(Date.now()), "yyyyMMdd_HHmmss");
-        let blob = new Blob([JSON.stringify(response.data)], {
-          type: "application/json;charset=utf-8",
-        });
-        let downloadLink = angular.element("<a></a>");
-        downloadLink.attr("href", window.URL.createObjectURL(blob));
-        downloadLink.attr("download", filename);
-        downloadLink[0].click();
-      },
-      () => alert("Aborting: No Jobs defined or unknown error.")
+        function(response) {
+          const filename =
+          'JobExport_' +
+          $filter('date')(new Date(Date.now()), 'yyyyMMdd_HHmmss');
+          const blob = new Blob([JSON.stringify(response.data)], {
+            type: 'application/json;charset=utf-8',
+          });
+          const downloadLink = angular.element('<a></a>');
+          downloadLink.attr('href', window.URL.createObjectURL(blob));
+          downloadLink.attr('download', filename);
+          downloadLink[0].click();
+        },
+        () => alert('Aborting: No Jobs defined or unknown error.')
     );
   };
 }

--- a/src/ui/src/js/controllers/job/import_jobs.js
+++ b/src/ui/src/js/controllers/job/import_jobs.js
@@ -1,11 +1,11 @@
-import template from "../../../templates/import_jobs.html";
+import template from '../../../templates/import_jobs.html';
 
 jobImportController.$inject = [
-  "$scope",
-  "$rootScope",
-  "$uibModal",
-  "$state",
-  "JobService",
+  '$scope',
+  '$rootScope',
+  '$uibModal',
+  '$state',
+  'JobService',
 ];
 
 /**
@@ -13,40 +13,41 @@ jobImportController.$inject = [
  * @param  {Object} $scope            Angular's $scope object.
  * @param  {Object} $rootScope        Angular's $rootScope object.
  * @param  {Object} $uibModal         Angular UI's $uibModal object.
+ * @param  {Object} $state            State
  * @param  {Object} JobService        Beer-Garden's job service.
  */
 export function jobImportController(
-  $scope,
-  $rootScope,
-  $uibModal,
-  $state,
-  JobService
+    $scope,
+    $rootScope,
+    $uibModal,
+    $state,
+    JobService
 ) {
   $scope.response = $rootScope.sysResponse;
   $scope.data = $rootScope.systems;
 
-  $scope.openImportJobsPopup = function () {
-    let popupInstance = $uibModal.open({
+  $scope.openImportJobsPopup = function() {
+    const popupInstance = $uibModal.open({
       animation: true,
-      controller: "JobImportModalController",
+      controller: 'JobImportModalController',
       template: template,
     });
 
-    popupInstance.result.then(function (resolvedResponse) {
-      let jsonFileContents = resolvedResponse.jsonFileContents;
+    popupInstance.result.then(function(resolvedResponse) {
+      const jsonFileContents = resolvedResponse.jsonFileContents;
       JobService.importJobs(jsonFileContents).then(
-        function (response) {
-          $state.reload();
-        },
-        function (response) {
-          alert("Failure! Server returned status " + response.status);
-        }
+          function(response) {
+            $state.reload();
+          },
+          function(response) {
+            alert('Failure! Server returned status ' + response.status);
+          }
       );
     }, angular.noop);
   };
 }
 
-jobImportModalController.$inject = ["$scope", "$window", "$uibModalInstance"];
+jobImportModalController.$inject = ['$scope', '$window', '$uibModalInstance'];
 
 /**
  * jobImportModalController - Controller for the job import popup window.
@@ -60,17 +61,17 @@ export function jobImportModalController($scope, $window, $uibModalInstance) {
   $scope.fileContents = undefined;
   $scope.fileIsGoodJson = true;
 
-  $scope.inputClicker = function () {
-    $window.document.getElementById("fileSelectHiddenControl").click();
+  $scope.inputClicker = function() {
+    $window.document.getElementById('fileSelectHiddenControl').click();
   };
 
-  $scope.doImport = function () {
-    $scope.import["jsonFileContents"] = $scope.fileContents;
+  $scope.doImport = function() {
+    $scope.import['jsonFileContents'] = $scope.fileContents;
     $uibModalInstance.close($scope.import);
   };
 
-  $scope.cancelImport = function () {
-    $uibModalInstance.dismiss("cancel");
+  $scope.cancelImport = function() {
+    $uibModalInstance.dismiss('cancel');
   };
 
   function isParsableJson(string) {
@@ -82,15 +83,15 @@ export function jobImportModalController($scope, $window, $uibModalInstance) {
     return true;
   }
 
-  $scope.onFileSelected = function (event) {
-    let theFile = event.target.files[0];
+  $scope.onFileSelected = function(event) {
+    const theFile = event.target.files[0];
     $scope.fileName = theFile.name;
 
-    let reader = new FileReader();
-    reader.onload = function (e) {
-      $scope.$apply(function () {
-        let result = reader.result;
-        let isGoodJson = isParsableJson(result);
+    const reader = new FileReader();
+    reader.onload = function(e) {
+      $scope.$apply(function() {
+        const result = reader.result;
+        const isGoodJson = isParsableJson(result);
 
         if (isGoodJson) {
           $scope.fileContents = result;

--- a/src/ui/src/js/controllers/job/import_jobs.js
+++ b/src/ui/src/js/controllers/job/import_jobs.js
@@ -21,7 +21,7 @@ export function jobImportController(
     $rootScope,
     $uibModal,
     $state,
-    JobService
+    JobService,
 ) {
   $scope.response = $rootScope.sysResponse;
   $scope.data = $rootScope.systems;
@@ -41,7 +41,7 @@ export function jobImportController(
           },
           function(response) {
             alert('Failure! Server returned status ' + response.status);
-          }
+          },
       );
     }, angular.noop);
   };

--- a/src/ui/src/js/controllers/job_index.js
+++ b/src/ui/src/js/controllers/job_index.js
@@ -1,6 +1,6 @@
-import { formatDate } from "../services/utility_service.js";
+import {formatDate} from '../services/utility_service.js';
 
-jobIndexController.$inject = ["$scope", "JobService"];
+jobIndexController.$inject = ['$scope', 'JobService'];
 
 /**
  * jobIndexController - Controller for the job index page.
@@ -8,14 +8,14 @@ jobIndexController.$inject = ["$scope", "JobService"];
  * @param  {Object} JobService  Beer-Garden's job service.
  */
 export default function jobIndexController($scope, JobService) {
-  $scope.setWindowTitle("scheduler");
+  $scope.setWindowTitle('scheduler');
 
-  $scope.successCallback = function (response) {
+  $scope.successCallback = function(response) {
     $scope.response = response;
     $scope.data = response.data;
   };
 
-  $scope.failureCallback = function (response) {
+  $scope.failureCallback = function(response) {
     $scope.response = response;
     $scope.data = {};
   };
@@ -29,7 +29,7 @@ export default function jobIndexController($scope, JobService) {
     JobService.getJobs().then($scope.successCallback, $scope.failureCallback);
   }
 
-  $scope.$on("userChange", () => {
+  $scope.$on('userChange', () => {
     loadJobs();
   });
 

--- a/src/ui/src/js/controllers/job_view.js
+++ b/src/ui/src/js/controllers/job_view.js
@@ -1,13 +1,13 @@
-import { formatDate, formatJsonDisplay } from "../services/utility_service.js";
-import modalTemplate from "../../templates/reset_interval_modal.html";
+import {formatDate, formatJsonDisplay} from '../services/utility_service.js';
+import modalTemplate from '../../templates/reset_interval_modal.html';
 
 jobViewController.$inject = [
-  "$scope",
-  "$rootScope",
-  "$state",
-  "$stateParams",
-  "$uibModal",
-  "JobService",
+  '$scope',
+  '$rootScope',
+  '$state',
+  '$stateParams',
+  '$uibModal',
+  'JobService',
 ];
 
 /**
@@ -20,62 +20,62 @@ jobViewController.$inject = [
  * @param  {Object} JobService    Beer-Garden's job service.
  */
 export function jobViewController(
-  $scope,
-  $rootScope,
-  $state,
-  $stateParams,
-  $uibModal,
-  JobService
+    $scope,
+    $rootScope,
+    $state,
+    $stateParams,
+    $uibModal,
+    JobService
 ) {
-  $scope.setWindowTitle("scheduler");
+  $scope.setWindowTitle('scheduler');
 
-  $scope.formattedRequestTemplate = "";
-  $scope.formattedTrigger = "";
+  $scope.formattedRequestTemplate = '';
+  $scope.formattedTrigger = '';
 
-  $scope.loadPreview = function (_editor) {
+  $scope.loadPreview = function(_editor) {
     formatJsonDisplay(_editor, true);
   };
 
   $scope.formatDate = formatDate;
 
-  $scope.successCallback = function (response) {
+  $scope.successCallback = function(response) {
     $scope.response = response;
     $scope.data = response.data;
 
     $scope.formattedRequestTemplate = JSON.stringify(
-      $scope.data.request_template,
-      undefined,
-      2
+        $scope.data.request_template,
+        undefined,
+        2
     );
     $scope.formattedTrigger = JSON.stringify($scope.data.trigger, undefined, 2);
   };
 
-  $scope.resumeJob = function (jobId) {
+  $scope.resumeJob = function(jobId) {
     JobService.resumeJob(jobId).then(
-      $scope.successCallback,
-      $scope.failureCallback
+        $scope.successCallback,
+        $scope.failureCallback
     );
   };
 
-  $scope.pauseJob = function (jobId) {
+  $scope.pauseJob = function(jobId) {
     JobService.pauseJob(jobId).then(
-      $scope.successCallback,
-      $scope.failureCallback
+        $scope.successCallback,
+        $scope.failureCallback
     );
   };
 
-  $scope.updateJob = function (job) {
-    $state.go("base.jobscreaterequest", { job: job });
+  $scope.updateJob = function(job) {
+    $state.go('base.jobscreaterequest', {job: job});
   };
 
-  $scope.deleteJob = function (jobId) {
+  $scope.deleteJob = function(jobId) {
     JobService.deleteJob(jobId).then(
-      $state.go("base.jobs"),
-      $scope.failureCallback
+        $state.go('base.jobs'),
+        $scope.failureCallback
     );
   };
 
-  $scope.failureCallback = function (response) {
+  $scope.failureCallback = function(response) {
     $scope.response = response;
     $scope.data = [];
   };
@@ -85,12 +85,12 @@ export function jobViewController(
     $scope.data = [];
 
     JobService.getJob($stateParams.id).then(
-      $scope.successCallback,
-      $scope.failureCallback
+        $scope.successCallback,
+        $scope.failureCallback
     );
   }
 
-  $scope.$on("userChange", () => {
+  $scope.$on('userChange', () => {
     loadJob();
   });
 
@@ -101,15 +101,15 @@ export function jobViewController(
     const resettingInterval = $scope.resetTheInterval;
 
     JobService.runAdHocJob(jobId, $scope.resetTheInterval).then(
-      function (response) {
-        console.log(
-          `Ad hoc run of ID ${jobId}; reset interval: ${resettingInterval}`
-        );
-        $state.go("base.jobs");
-      },
-      function (response) {
-        alert("Failure! Server returned status " + response.status);
-      }
+        function(response) {
+          console.log(
+              `Ad hoc run of ID ${jobId}; reset interval: ${resettingInterval}`
+          );
+          $state.go('base.jobs');
+        },
+        function(response) {
+          alert('Failure! Server returned status ' + response.status);
+        }
     );
   }
 
@@ -127,26 +127,26 @@ export function jobViewController(
   /*
    * Schedule a job to be run immediately.
    */
-  $scope.runJobNow = function (jobData) {
+  $scope.runJobNow = function(jobData) {
     $scope.resetTheInterval = false;
 
-    let theTriggerIsInterval = isIntervalTrigger(jobData["trigger_type"]);
-    let jobId = jobData["id"];
+    const theTriggerIsInterval = isIntervalTrigger(jobData['trigger_type']);
+    const jobId = jobData['id'];
 
     if (theTriggerIsInterval) {
       // open modal dialog to update resetTheInterval
-      let popupInstance = $uibModal.open({
+      const popupInstance = $uibModal.open({
         animation: true,
         template: modalTemplate,
-        controller: "JobRunNowModalController",
+        controller: 'JobRunNowModalController',
       });
 
       popupInstance.result.then(
-        function (result) {
-          $scope.resetTheInterval = result;
-          runAdHoc(jobId);
-        },
-        () => console.log("Ad hoc run cancelled")
+          function(result) {
+            $scope.resetTheInterval = result;
+            runAdHoc(jobId);
+          },
+          () => console.log('Ad hoc run cancelled')
       );
     } else {
       runAdHoc(jobId);
@@ -156,7 +156,7 @@ export function jobViewController(
   loadJob();
 }
 
-jobRunNowModalController.$inject = ["$scope", "$uibModalInstance"];
+jobRunNowModalController.$inject = ['$scope', '$uibModalInstance'];
 
 /**
  * jobRunNowModalController - Controller for the reset interval popup.
@@ -164,11 +164,11 @@ jobRunNowModalController.$inject = ["$scope", "$uibModalInstance"];
  * @param  {Object} $uibModalInstance  Object for the modal popup window.
  */
 export function jobRunNowModalController($scope, $uibModalInstance) {
-  $scope.setIntervalReset = function (result) {
+  $scope.setIntervalReset = function(result) {
     $uibModalInstance.close(result);
   };
 
-  $scope.cancelRunNow = function () {
-    $uibModalInstance.dismiss("cancel");
+  $scope.cancelRunNow = function() {
+    $uibModalInstance.dismiss('cancel');
   };
 }

--- a/src/ui/src/js/controllers/job_view.js
+++ b/src/ui/src/js/controllers/job_view.js
@@ -25,7 +25,7 @@ export function jobViewController(
     $state,
     $stateParams,
     $uibModal,
-    JobService
+    JobService,
 ) {
   $scope.setWindowTitle('scheduler');
 
@@ -45,7 +45,7 @@ export function jobViewController(
     $scope.formattedRequestTemplate = JSON.stringify(
         $scope.data.request_template,
         undefined,
-        2
+        2,
     );
     $scope.formattedTrigger = JSON.stringify($scope.data.trigger, undefined, 2);
   };
@@ -53,14 +53,14 @@ export function jobViewController(
   $scope.resumeJob = function(jobId) {
     JobService.resumeJob(jobId).then(
         $scope.successCallback,
-        $scope.failureCallback
+        $scope.failureCallback,
     );
   };
 
   $scope.pauseJob = function(jobId) {
     JobService.pauseJob(jobId).then(
         $scope.successCallback,
-        $scope.failureCallback
+        $scope.failureCallback,
     );
   };
 
@@ -71,7 +71,7 @@ export function jobViewController(
   $scope.deleteJob = function(jobId) {
     JobService.deleteJob(jobId).then(
         $state.go('base.jobs'),
-        $scope.failureCallback
+        $scope.failureCallback,
     );
   };
 
@@ -86,7 +86,7 @@ export function jobViewController(
 
     JobService.getJob($stateParams.id).then(
         $scope.successCallback,
-        $scope.failureCallback
+        $scope.failureCallback,
     );
   }
 
@@ -103,13 +103,13 @@ export function jobViewController(
     JobService.runAdHocJob(jobId, $scope.resetTheInterval).then(
         function(response) {
           console.log(
-              `Ad hoc run of ID ${jobId}; reset interval: ${resettingInterval}`
+              `Ad hoc run of ID ${jobId}; reset interval: ${resettingInterval}`,
           );
           $state.go('base.jobs');
         },
         function(response) {
           alert('Failure! Server returned status ' + response.status);
-        }
+        },
     );
   }
 
@@ -146,7 +146,7 @@ export function jobViewController(
             $scope.resetTheInterval = result;
             runAdHoc(jobId);
           },
-          () => console.log('Ad hoc run cancelled')
+          () => console.log('Ad hoc run cancelled'),
       );
     } else {
       runAdHoc(jobId);

--- a/src/ui/src/js/controllers/login.js
+++ b/src/ui/src/js/controllers/login.js
@@ -1,11 +1,11 @@
-import _ from "lodash";
-import angular from "angular";
+import _ from 'lodash';
+import angular from 'angular';
 
 loginController.$inject = [
-  "$scope",
-  "$timeout",
-  "$uibModalInstance",
-  "TokenService",
+  '$scope',
+  '$timeout',
+  '$uibModalInstance',
+  'TokenService',
 ];
 
 /**
@@ -16,35 +16,35 @@ loginController.$inject = [
  * @param  {Object} TokenService  TokenService object.
  */
 export default function loginController(
-  $scope,
-  $timeout,
-  $uibModalInstance,
-  TokenService
+    $scope,
+    $timeout,
+    $uibModalInstance,
+    TokenService
 ) {
   $scope.model = {};
 
-  $scope.doLogin = function () {
+  $scope.doLogin = function() {
     $scope.badUsername = false;
     $scope.badPassword = false;
 
     TokenService.doLogin($scope.model.username, $scope.model.password).then(
-      (response) => {
-        $uibModalInstance.close();
-      },
-      () => {
-        if (_.isUndefined($scope.model.username)) {
-          $scope.badUsername = true;
-          angular.element('input[type="text"]').focus();
-        } else {
-          $scope.badPassword = true;
-          $scope.model.password = undefined;
-          angular.element('input[type="password"]').focus();
+        (response) => {
+          $uibModalInstance.close();
+        },
+        () => {
+          if (_.isUndefined($scope.model.username)) {
+            $scope.badUsername = true;
+            angular.element('input[type="text"]').focus();
+          } else {
+            $scope.badPassword = true;
+            $scope.model.password = undefined;
+            angular.element('input[type="password"]').focus();
+          }
         }
-      }
     );
   };
 
-  $scope.cancel = function () {
+  $scope.cancel = function() {
     $uibModalInstance.dismiss();
   };
 

--- a/src/ui/src/js/controllers/login.js
+++ b/src/ui/src/js/controllers/login.js
@@ -19,7 +19,7 @@ export default function loginController(
     $scope,
     $timeout,
     $uibModalInstance,
-    TokenService
+    TokenService,
 ) {
   $scope.model = {};
 
@@ -40,7 +40,7 @@ export default function loginController(
             $scope.model.password = undefined;
             angular.element('input[type="password"]').focus();
           }
-        }
+        },
     );
   };
 

--- a/src/ui/src/js/controllers/request_index.js
+++ b/src/ui/src/js/controllers/request_index.js
@@ -27,7 +27,7 @@ export default function requestIndexController(
     DTOptionsBuilder,
     DTColumnBuilder,
     RequestService,
-    EventService
+    EventService,
 ) {
   $scope.setWindowTitle('requests');
 
@@ -37,7 +37,7 @@ export default function requestIndexController(
       .withOption('autoWidth', false)
       .withOption(
           'pageLength',
-          localStorageService.get('_request_index_length') || 10
+          localStorageService.get('_request_index_length') || 10,
       )
       .withOption('ajax', function(data, callback, settings) {
       // Need to also request ID for the href
@@ -76,7 +76,7 @@ export default function requestIndexController(
             },
             (response) => {
               $scope.response = response;
-            }
+            },
         );
       })
       .withLightColumnFilter({

--- a/src/ui/src/js/controllers/request_index.js
+++ b/src/ui/src/js/controllers/request_index.js
@@ -1,13 +1,13 @@
-import { formatDate } from "../services/utility_service.js";
+import {formatDate} from '../services/utility_service.js';
 
 requestIndexController.$inject = [
-  "$scope",
-  "$compile",
-  "localStorageService",
-  "DTOptionsBuilder",
-  "DTColumnBuilder",
-  "RequestService",
-  "EventService",
+  '$scope',
+  '$compile',
+  'localStorageService',
+  'DTOptionsBuilder',
+  'DTColumnBuilder',
+  'RequestService',
+  'EventService',
 ];
 
 /**
@@ -21,235 +21,235 @@ requestIndexController.$inject = [
  * @param  {Object} EventService      Beer-Garden Event Service.
  */
 export default function requestIndexController(
-  $scope,
-  $compile,
-  localStorageService,
-  DTOptionsBuilder,
-  DTColumnBuilder,
-  RequestService,
-  EventService
+    $scope,
+    $compile,
+    localStorageService,
+    DTOptionsBuilder,
+    DTColumnBuilder,
+    RequestService,
+    EventService
 ) {
-  $scope.setWindowTitle("requests");
+  $scope.setWindowTitle('requests');
 
   $scope.requests = {};
 
   $scope.dtOptions = DTOptionsBuilder.newOptions()
-    .withOption("autoWidth", false)
-    .withOption(
-      "pageLength",
-      localStorageService.get("_request_index_length") || 10
-    )
-    .withOption("ajax", function (data, callback, settings) {
+      .withOption('autoWidth', false)
+      .withOption(
+          'pageLength',
+          localStorageService.get('_request_index_length') || 10
+      )
+      .withOption('ajax', function(data, callback, settings) {
       // Need to also request ID for the href
-      data.columns.push({ data: "id" });
+        data.columns.push({data: 'id'});
 
-      // Take include_children value from the checkbox
-      if ($("#childCheck").is(":checked")) {
-        data.include_children = true;
-        data.columns.push({ data: "parent" });
-      }
-      if ($("#hiddenRequestCheck").is(":checked")) {
-        data.include_hidden = true;
-        data.columns.push({ data: "hidden" });
-      }
-
-      // Not urlencoding semicolons in the search values breaks the backend
-      for (let column of data.columns) {
-        if (column.search && column.search.value) {
-          column.search.value = column.search.value.replace(/;/g, "%3B");
+        // Take include_children value from the checkbox
+        if ($('#childCheck').is(':checked')) {
+          data.include_children = true;
+          data.columns.push({data: 'parent'});
         }
-      }
-
-      RequestService.getRequests(data).then(
-        (response) => {
-          $scope.response = response;
-
-          callback({
-            data: response.data,
-            draw: response.headers("draw"),
-            recordsFiltered: response.headers("recordsFiltered"),
-            recordsTotal: response.headers("recordsTotal"),
-          });
-
-          // Hide the 'new data' notification
-          $("#newData").css("visibility", "hidden");
-        },
-        (response) => {
-          $scope.response = response;
+        if ($('#hiddenRequestCheck').is(':checked')) {
+          data.include_hidden = true;
+          data.columns.push({data: 'hidden'});
         }
-      );
-    })
-    .withLightColumnFilter({
-      0: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Command Filter" },
-      },
-      1: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Namespace Filter" },
-      },
-      2: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "System Filter" },
-      },
-      3: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Version Filter" },
-      },
-      4: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Instance Filter" },
-      },
-      5: {
-        html: "select",
-        type: "text",
-        cssClass: "form-inline form-control",
-        values: [
-          { value: "", label: "" },
-          { value: "CREATED", label: "CREATED" },
-          { value: "RECEIVED", label: "RECEIVED" },
-          { value: "IN_PROGRESS", label: "IN PROGRESS" },
-          { value: "CANCELED", label: "CANCELED" },
-          { value: "SUCCESS", label: "SUCCESS" },
-          { value: "ERROR", label: "ERROR" },
-        ],
-      },
-      6: {
-        html: "range",
-        type: "text",
-        attr: {
-          class: "form-inline form-control w-50",
+
+        // Not urlencoding semicolons in the search values breaks the backend
+        for (const column of data.columns) {
+          if (column.search && column.search.value) {
+            column.search.value = column.search.value.replace(/;/g, '%3B');
+          }
+        }
+
+        RequestService.getRequests(data).then(
+            (response) => {
+              $scope.response = response;
+
+              callback({
+                data: response.data,
+                draw: response.headers('draw'),
+                recordsFiltered: response.headers('recordsFiltered'),
+                recordsTotal: response.headers('recordsTotal'),
+              });
+
+              // Hide the 'new data' notification
+              $('#newData').css('visibility', 'hidden');
+            },
+            (response) => {
+              $scope.response = response;
+            }
+        );
+      })
+      .withLightColumnFilter({
+        0: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'Command Filter'},
         },
-        startAttr: {
-          placeholder: "start",
-          title: "Start Timestamp Filter",
+        1: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'Namespace Filter'},
         },
-        endAttr: {
-          placeholder: "end",
-          title: "End Timestamp Filter",
+        2: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'System Filter'},
         },
-        picker: {
-          format: "YYYY-MM-DD HH:mm:ss",
-          showClear: true,
-          showTodayButton: true,
-          useCurrent: false,
+        3: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'Version Filter'},
         },
-      },
-      7: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Comment Filter" },
-      },
-    })
-    .withDataProp("data")
-    .withOption("order", [6, "desc"])
-    .withOption("serverSide", true)
-    .withOption("refreshButton", true)
-    .withOption("childContainer", true)
-    .withOption("hiddenRequestContainer", true)
-    .withOption("newData", true)
-    .withPaginationType("full_numbers")
-    .withBootstrap()
-    .withOption("createdRow", function (row, data, dataIndex) {
-      $compile(angular.element(row).contents())($scope);
-    });
+        4: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'Instance Filter'},
+        },
+        5: {
+          html: 'select',
+          type: 'text',
+          cssClass: 'form-inline form-control',
+          values: [
+            {value: '', label: ''},
+            {value: 'CREATED', label: 'CREATED'},
+            {value: 'RECEIVED', label: 'RECEIVED'},
+            {value: 'IN_PROGRESS', label: 'IN PROGRESS'},
+            {value: 'CANCELED', label: 'CANCELED'},
+            {value: 'SUCCESS', label: 'SUCCESS'},
+            {value: 'ERROR', label: 'ERROR'},
+          ],
+        },
+        6: {
+          html: 'range',
+          type: 'text',
+          attr: {
+            class: 'form-inline form-control w-50',
+          },
+          startAttr: {
+            placeholder: 'start',
+            title: 'Start Timestamp Filter',
+          },
+          endAttr: {
+            placeholder: 'end',
+            title: 'End Timestamp Filter',
+          },
+          picker: {
+            format: 'YYYY-MM-DD HH:mm:ss',
+            showClear: true,
+            showTodayButton: true,
+            useCurrent: false,
+          },
+        },
+        7: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'Comment Filter'},
+        },
+      })
+      .withDataProp('data')
+      .withOption('order', [6, 'desc'])
+      .withOption('serverSide', true)
+      .withOption('refreshButton', true)
+      .withOption('childContainer', true)
+      .withOption('hiddenRequestContainer', true)
+      .withOption('newData', true)
+      .withPaginationType('full_numbers')
+      .withBootstrap()
+      .withOption('createdRow', function(row, data, dataIndex) {
+        $compile(angular.element(row).contents())($scope);
+      });
 
   $scope.dtColumns = [
-    DTColumnBuilder.newColumn("command")
-      .withTitle("Command")
-      .renderWith(function (data, type, full) {
-        let display = "";
+    DTColumnBuilder.newColumn('command')
+        .withTitle('Command')
+        .renderWith(function(data, type, full) {
+          let display = '';
 
-        if (full.parent) {
-          display +=
+          if (full.parent) {
+            display +=
             '<span style="margin-right: 2px;"' +
             `uib-popover="${full.parent.command}"` +
-            "popover-trigger=\"'mouseenter'\"" +
+            'popover-trigger="\'mouseenter\'"' +
             'popover-title="parent request"' +
             'popover-animation="true"' +
             'popover-placement="top-left">' +
             `<a ui-sref="base.request({requestId: '${full.parent.id}'})" ` +
             'class="fa fa-level-up fa-fw">' +
-            "</a>" +
-            "</span>";
-        }
+            '</a>' +
+            '</span>';
+          }
 
-        display +=
+          display +=
           `<a ui-sref="base.request({requestId: '${full.id}'})">` +
           data +
-          "</a>";
+          '</a>';
 
-        if (full.hidden) {
-          display +=
+          if (full.hidden) {
+            display +=
             '<span class="fa fa-user-secret pull-right" style="font-size: 20px;"></span>';
-        }
+          }
 
-        return display;
-      }),
-    DTColumnBuilder.newColumn("namespace").withTitle("Namespace"),
-    DTColumnBuilder.newColumn("system")
-      .withTitle("System")
-      .renderWith(function (data, type, full) {
-        let systemName = data;
-        if (full["metadata"] && full["metadata"]["system_display_name"]) {
-          systemName = full["metadata"]["system_display_name"];
-        }
-        return systemName;
-      }),
-    DTColumnBuilder.newColumn("system_version")
-      .withTitle("Version")
-      .renderWith(function (data, type, full) {
-        return `<a ui-sref="base.system({
+          return display;
+        }),
+    DTColumnBuilder.newColumn('namespace').withTitle('Namespace'),
+    DTColumnBuilder.newColumn('system')
+        .withTitle('System')
+        .renderWith(function(data, type, full) {
+          let systemName = data;
+          if (full['metadata'] && full['metadata']['system_display_name']) {
+            systemName = full['metadata']['system_display_name'];
+          }
+          return systemName;
+        }),
+    DTColumnBuilder.newColumn('system_version')
+        .withTitle('Version')
+        .renderWith(function(data, type, full) {
+          return `<a ui-sref="base.system({
           systemName: '${full.system}',
           systemVersion: '${full.system_version}',
           namespace: '${full.namespace}'})"
           >${data}</a>`;
-      }),
-    DTColumnBuilder.newColumn("instance_name").withTitle("Instance"),
-    DTColumnBuilder.newColumn("status").withTitle("Status"),
-    DTColumnBuilder.newColumn("created_at")
-      .withTitle("Created")
-      .withOption("type", "date")
-      .withOption("width", "22%")
-      .renderWith(function (data, type, full) {
-        return formatDate(data);
-      }),
-    DTColumnBuilder.newColumn("comment").withTitle("Comment"),
-    DTColumnBuilder.newColumn("metadata").notVisible(),
+        }),
+    DTColumnBuilder.newColumn('instance_name').withTitle('Instance'),
+    DTColumnBuilder.newColumn('status').withTitle('Status'),
+    DTColumnBuilder.newColumn('created_at')
+        .withTitle('Created')
+        .withOption('type', 'date')
+        .withOption('width', '22%')
+        .renderWith(function(data, type, full) {
+          return formatDate(data);
+        }),
+    DTColumnBuilder.newColumn('comment').withTitle('Comment'),
+    DTColumnBuilder.newColumn('metadata').notVisible(),
   ];
 
-  $scope.instanceCreated = function (_instance) {
+  $scope.instanceCreated = function(_instance) {
     $scope.dtInstance = _instance;
 
-    $("#requestIndexTable").on("length.dt", (event, settings, len) => {
-      localStorageService.set("_request_index_length", len);
+    $('#requestIndexTable').on('length.dt', (event, settings, len) => {
+      localStorageService.set('_request_index_length', len);
     });
   };
 
-  EventService.addCallback("request_index", (event) => {
+  EventService.addCallback('request_index', (event) => {
     if (!event.error) {
       switch (event.name) {
-        case "REQUEST_CREATED":
-        case "REQUEST_STARTED":
-        case "REQUEST_COMPLETED":
+        case 'REQUEST_CREATED':
+        case 'REQUEST_STARTED':
+        case 'REQUEST_COMPLETED':
           if ($scope.dtInstance) {
-            $("#newData").css("visibility", "visible");
+            $('#newData').css('visibility', 'visible');
           }
           break;
       }
     }
   });
 
-  $scope.$on("$destroy", function () {
-    EventService.removeCallback("request_index");
+  $scope.$on('$destroy', function() {
+    EventService.removeCallback('request_index');
   });
 
-  $scope.$on("userChange", function () {
+  $scope.$on('userChange', function() {
     $scope.response = undefined;
 
     if ($scope.dtInstance) {

--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -1,18 +1,18 @@
-import _ from "lodash";
-import sizeOf from "object-sizeof";
-import { formatDate, formatJsonDisplay } from "../services/utility_service.js";
+import _ from 'lodash';
+import sizeOf from 'object-sizeof';
+import {formatDate, formatJsonDisplay} from '../services/utility_service.js';
 
 requestViewController.$inject = [
-  "$scope",
-  "$state",
-  "$stateParams",
-  "$timeout",
-  "$animate",
-  "$sce",
-  "localStorageService",
-  "RequestService",
-  "SystemService",
-  "EventService",
+  '$scope',
+  '$state',
+  '$stateParams',
+  '$timeout',
+  '$animate',
+  '$sce',
+  'localStorageService',
+  'RequestService',
+  'SystemService',
+  'EventService',
 ];
 
 /**
@@ -29,30 +29,30 @@ requestViewController.$inject = [
  * @param  {Object} EventService       Beer-Garden's Event Service.
  */
 export default function requestViewController(
-  $scope,
-  $state,
-  $stateParams,
-  $timeout,
-  $animate,
-  $sce,
-  localStorageService,
-  RequestService,
-  SystemService,
-  EventService
+    $scope,
+    $state,
+    $stateParams,
+    $timeout,
+    $animate,
+    $sce,
+    localStorageService,
+    RequestService,
+    SystemService,
+    EventService
 ) {
   $scope.request = undefined;
   $scope.complete = false;
   $scope.instanceStatus = undefined;
   $scope.timeoutRequest = undefined;
   $scope.children = [];
-  $scope.filename = "";
+  $scope.filename = '';
   $scope.downloadVisible = false;
   $scope.childrenDisplay = [];
   $scope.childrenCollapsed = true;
   $scope.rawOutput = undefined;
-  $scope.htmlOutput = "";
-  $scope.jsonOutput = "";
-  $scope.formattedParameters = "";
+  $scope.htmlOutput = '';
+  $scope.jsonOutput = '';
+  $scope.formattedParameters = '';
   $scope.formattedAvailable = false;
   $scope.formatErrorTitle = undefined;
   $scope.formatErrorMsg = undefined;
@@ -60,70 +60,70 @@ export default function requestViewController(
   $scope.disabledPourItAgain = false;
   $scope.msgPourItAgain = null;
 
-  $scope.isMaximized = localStorageService.get("isMaximized");
+  $scope.isMaximized = localStorageService.get('isMaximized');
   if ($scope.isMaximized === null) {
     $scope.isMaximized = false;
   }
-  $scope.displayOutput = localStorageService.get("displayOutput");
+  $scope.displayOutput = localStorageService.get('displayOutput');
   if ($scope.displayOutput === null) {
     $scope.displayOutput = true;
   }
-  $scope.displayParameter = localStorageService.get("displayParameter");
+  $scope.displayParameter = localStorageService.get('displayParameter');
   if ($scope.displayParameter === null) {
     $scope.displayParameter = true;
   }
 
   $scope.statusDescriptions = {
     CREATED:
-      "The request has been validated by beer-garden and is on the " +
-      "queue awaiting processing.",
-    RECEIVED: "Not used.",
+      'The request has been validated by beer-garden and is on the ' +
+      'queue awaiting processing.',
+    RECEIVED: 'Not used.',
     IN_PROGRESS:
-      "The request has been received by the plugin and is " +
-      "actively being processed.",
-    CANCELED: "The request has been canceled and will not be processed.",
-    SUCCESS: "The request has completed successfully",
+      'The request has been received by the plugin and is ' +
+      'actively being processed.',
+    CANCELED: 'The request has been canceled and will not be processed.',
+    SUCCESS: 'The request has completed successfully',
     ERROR:
-      "The request encountered an error during processing and will " +
-      "not be reprocessed.",
-    INVALID: "The request did not pass validation checks",
+      'The request encountered an error during processing and will ' +
+      'not be reprocessed.',
+    INVALID: 'The request did not pass validation checks',
   };
 
   $scope.formatDate = formatDate;
 
-  $scope.loadPreview = function (_editor) {
+  $scope.loadPreview = function(_editor) {
     formatJsonDisplay(_editor, true);
   };
 
-  $scope.canRepeat = function (request) {
+  $scope.canRepeat = function(request) {
     return RequestService.isComplete(request);
   };
 
-  $scope.resize = function (resizeCell) {
+  $scope.resize = function(resizeCell) {
     $scope.isMaximized = !$scope.isMaximized;
 
-    if (resizeCell == "parameterCell") {
+    if (resizeCell == 'parameterCell') {
       $scope.displayOutput = !$scope.displayOutput;
-    } else if (resizeCell == "outputCell") {
+    } else if (resizeCell == 'outputCell') {
       $scope.displayParameter = !$scope.displayParameter;
     }
 
-    localStorageService.set("isMaximized", $scope.isMaximized);
-    localStorageService.set("displayOutput", $scope.displayOutput);
-    localStorageService.set("displayParameter", $scope.displayParameter);
+    localStorageService.set('isMaximized', $scope.isMaximized);
+    localStorageService.set('displayOutput', $scope.displayOutput);
+    localStorageService.set('displayParameter', $scope.displayParameter);
   };
 
-  $scope.showInstanceStatus = function (request, instanceStatus) {
+  $scope.showInstanceStatus = function(request, instanceStatus) {
     return (
       !$scope.canRepeat(request) &&
       instanceStatus &&
-      instanceStatus != "RUNNING"
+      instanceStatus != 'RUNNING'
     );
   };
 
-  $scope.formatOutput = function () {
-    $scope.htmlOutput = "";
-    $scope.jsonOutput = "";
+  $scope.formatOutput = function() {
+    $scope.htmlOutput = '';
+    $scope.jsonOutput = '';
     $scope.formattedAvailable = false;
     $scope.showFormatted = false;
     $scope.formatErrorTitle = undefined;
@@ -133,8 +133,8 @@ export default function requestViewController(
 
     try {
       if (rawOutput === undefined || rawOutput == null) {
-        rawOutput = "null";
-      } else if ($scope.request.output_type == "HTML") {
+        rawOutput = 'null';
+      } else if ($scope.request.output_type == 'HTML') {
         $scope.formattedAvailable = true;
         $scope.showFormatted = true;
 
@@ -144,9 +144,9 @@ export default function requestViewController(
         } else {
           $scope.htmlOutput = rawOutput;
         }
-      } else if ($scope.request.output_type == "JSON") {
+      } else if ($scope.request.output_type == 'JSON') {
         try {
-          let parsedOutput = JSON.parse(rawOutput);
+          const parsedOutput = JSON.parse(rawOutput);
           rawOutput = $scope.stringify(parsedOutput);
           if ($scope.countNodes($scope.formattedOutput) < 1000) {
             $scope.jsonOutput = rawOutput;
@@ -154,20 +154,20 @@ export default function requestViewController(
             $scope.showFormatted = true;
           } else {
             $scope.formatErrorTitle =
-              "Output is too large for collapsible view";
+              'Output is too large for collapsible view';
             $scope.formatErrorMsg =
-              "This output is valid JSON, but it's so big that " +
-              "displaying it in the collapsible viewer would crash the " +
-              "page. Downloading File might take a minute for UI to prepare.";
+              'This output is valid JSON, but it\'s so big that ' +
+              'displaying it in the collapsible viewer would crash the ' +
+              'page. Downloading File might take a minute for UI to prepare.';
           }
         } catch (err) {
-          $scope.formatErrorTitle = "This JSON didn't parse correctly";
+          $scope.formatErrorTitle = 'This JSON didn\'t parse correctly';
           $scope.formatErrorMsg =
-            "beer-garden was expecting this output to be JSON but it " +
-            "doesn't look like JSON. If this is happening often please " +
-            "let the plugin developer know.";
+            'beer-garden was expecting this output to be JSON but it ' +
+            'doesn\'t look like JSON. If this is happening often please ' +
+            'let the plugin developer know.';
         }
-      } else if ($scope.request.output_type == "STRING") {
+      } else if ($scope.request.output_type == 'STRING') {
         try {
           rawOutput = $scope.stringify(JSON.parse(rawOutput));
         } catch (err) {}
@@ -177,17 +177,17 @@ export default function requestViewController(
     }
   };
 
-  $scope.successCallback = function (request) {
+  $scope.successCallback = function(request) {
     $scope.request = request;
     $scope.filename = $scope.request.id;
-    let namespace = $scope.request.namespace || $scope.config.gardenName;
-    let request_system = SystemService.findSystem(
-      namespace,
-      $scope.request.system,
-      $scope.request.system_version
+    const namespace = $scope.request.namespace || $scope.config.gardenName;
+    const requestSystem = SystemService.findSystem(
+        namespace,
+        $scope.request.system,
+        $scope.request.system_version
     );
-    if (request_system != undefined) {
-      let commands = request_system.commands;
+    if (requestSystem != undefined) {
+      const commands = requestSystem.commands;
       for (let i = 0; i < commands.length; i++) {
         if (commands[i].name == request.command) {
           $scope.disabledPourItAgain = false;
@@ -195,38 +195,38 @@ export default function requestViewController(
           break;
         } else {
           $scope.disabledPourItAgain = true;
-          $scope.msgPourItAgain = "Unable to find command";
+          $scope.msgPourItAgain = 'Unable to find command';
         }
       }
     } else {
       $scope.disabledPourItAgain = true;
-      $scope.msgPourItAgain = "Unable to find system";
+      $scope.msgPourItAgain = 'Unable to find system';
     }
     $scope.setWindowTitle(
-      $scope.request.command,
-      $scope.request.metadata.system_display_name || $scope.request.system,
-      $scope.request.system_version,
-      $scope.request.instance_name,
-      "request"
+        $scope.request.command,
+        $scope.request.metadata.system_display_name || $scope.request.system,
+        $scope.request.system_version,
+        $scope.request.instance_name,
+        'request'
     );
 
     if (RequestService.isComplete($scope.request)) {
       if ($scope.request.output) {
         $scope.downloadVisible = true;
 
-        if ($scope.request.output_type == "STRING") {
-          $scope.filename += ".txt";
-        } else if ($scope.request.output_type == "HTML") {
-          $scope.filename += ".html";
-        } else if ($scope.request.output_type == "JSON") {
-          $scope.filename += ".json";
+        if ($scope.request.output_type == 'STRING') {
+          $scope.filename += '.txt';
+        } else if ($scope.request.output_type == 'HTML') {
+          $scope.filename += '.html';
+        } else if ($scope.request.output_type == 'JSON') {
+          $scope.filename += '.json';
         }
       }
 
       if (sizeOf($scope.request.output) > 5000000) {
-        $scope.formatErrorTitle = "Output is too large";
+        $scope.formatErrorTitle = 'Output is too large';
         $scope.formatErrorMsg =
-          "The output for this request is too large to display, please download instead";
+          'The output for this request is too large to display, please download instead';
       } else {
         $scope.formatOutput();
       }
@@ -237,10 +237,10 @@ export default function requestViewController(
     $scope.formattedParameters = $scope.stringify($scope.request.parameters);
 
     // Grab the status of the instance this request targets to display if necessary
-    let system = SystemService.findSystem(
-      $scope.request.namespace,
-      $scope.request.system,
-      $scope.request.system_version
+    const system = SystemService.findSystem(
+        $scope.request.namespace,
+        $scope.request.system,
+        $scope.request.system_version
     );
     $scope.instanceStatus = _.find(system.instances, {
       name: $scope.request.instance_name,
@@ -257,7 +257,7 @@ export default function requestViewController(
     }
   };
 
-  $scope.failureCallback = function (response) {
+  $scope.failureCallback = function(response) {
     $scope.response = response;
     $scope.request = response.data;
 
@@ -272,32 +272,33 @@ export default function requestViewController(
     $scope.setWindowTitle();
   };
 
-  $scope.redoRequest = function (request) {
+  $scope.redoRequest = function(request) {
     const newRequest = {
       system: request.system,
       system_version: request.system_version,
       command: request.command,
       instance_name: request.instance_name,
-      comment: request.comment || "",
+      comment: request.comment || '',
       parameters: request.parameters,
     };
-    $state.go("base.command", {
+    $state.go('base.command', {
       systemName: request.system,
       systemVersion: request.system_version,
       commandName: request.command,
-      namespace: request.namespace || $scope.config.gardenName, // Fix for v2 requests w/o a namespace
+      // Fix for v2 requests w/o a namespace
+      namespace: request.namespace || $scope.config.gardenName,
       request: newRequest,
     });
   };
 
-  $scope.childrenExist = function (children) {
+  $scope.childrenExist = function(children) {
     return children !== undefined && children !== null && children.length > 0;
   };
 
-  $scope.toggleChildren = function () {
-    $animate.enabled($("#requestTable"), true);
-    $scope.disableAnimation = $timeout(function () {
-      $animate.enabled($("#requestTable"), false);
+  $scope.toggleChildren = function() {
+    $animate.enabled($('#requestTable'), true);
+    $scope.disableAnimation = $timeout(function() {
+      $animate.enabled($('#requestTable'), false);
     }, 300);
 
     $scope.childrenCollapsed = !$scope.childrenCollapsed;
@@ -310,15 +311,15 @@ export default function requestViewController(
   };
 
   // Return true if any of the children or the parent have an error_class
-  $scope.showErrorColumn = function (request, children) {
-    return _.some(_.concat(children, [request]), "error_class");
+  $scope.showErrorColumn = function(request, children) {
+    return _.some(_.concat(children, [request]), 'error_class');
   };
 
-  $scope.hasParent = function (request) {
+  $scope.hasParent = function(request) {
     return request.parent !== undefined && request.parent !== null;
   };
 
-  $scope.getParentTree = function (request) {
+  $scope.getParentTree = function(request) {
     if (!$scope.hasParent(request)) {
       return [request];
     } else {
@@ -326,13 +327,13 @@ export default function requestViewController(
     }
   };
 
-  $scope.stringify = function (data) {
+  $scope.stringify = function(data) {
     return JSON.stringify(data, undefined, 2);
   };
 
-  $scope.countNodes = function (obj) {
+  $scope.countNodes = function(obj) {
     // Arrays have type object too
-    if (typeof obj != "object") {
+    if (typeof obj != 'object') {
       return 1;
     }
 
@@ -344,14 +345,14 @@ export default function requestViewController(
   };
 
   function eventCallback(event) {
-    if (event.name.startsWith("REQUEST")) {
+    if (event.name.startsWith('REQUEST')) {
       if (event.payload.id == $stateParams.requestId) {
         $scope.successCallback(event.payload);
-      } else if (_.get(event, "payload.parent.id") == $stateParams.requestId) {
-        if (event.name == "REQUEST_CREATED") {
+      } else if (_.get(event, 'payload.parent.id') == $stateParams.requestId) {
+        if (event.name == 'REQUEST_CREATED') {
           $scope.children.push(event.payload);
         } else {
-          let child = _.find($scope.children, { id: event.payload.id });
+          const child = _.find($scope.children, {id: event.payload.id});
 
           if (!child) {
             // If we missed the REQUEST_CREATED just push this one in there
@@ -370,13 +371,13 @@ export default function requestViewController(
     }
   }
 
-  EventService.addCallback("request_view", (event) => {
+  EventService.addCallback('request_view', (event) => {
     $scope.$apply(() => {
       eventCallback(event);
     });
   });
-  $scope.$on("$destroy", function () {
-    EventService.removeCallback("request_view");
+  $scope.$on('$destroy', function() {
+    EventService.removeCallback('request_view');
   });
 
   function loadRequest() {
@@ -389,7 +390,7 @@ export default function requestViewController(
     }, $scope.failureCallback);
   }
 
-  $scope.$on("userChange", function () {
+  $scope.$on('userChange', function() {
     loadRequest();
   });
 
@@ -402,24 +403,24 @@ export default function requestViewController(
  */
 export function slideAnimation() {
   return {
-    enter: function (element, doneFn) {
-      $(element).children("td").hide();
-      $(element).children("td").slideDown(250);
+    enter: function(element, doneFn) {
+      $(element).children('td').hide();
+      $(element).children('td').slideDown(250);
       $(element)
-        .children("td")
-        .children("div")
-        .slideDown(250, function () {
-          doneFn();
-        });
+          .children('td')
+          .children('div')
+          .slideDown(250, function() {
+            doneFn();
+          });
     },
-    leave: function (element, doneFn) {
-      $(element).children("td").slideUp(250);
+    leave: function(element, doneFn) {
+      $(element).children('td').slideUp(250);
       $(element)
-        .children("td")
-        .children("div")
-        .slideUp(250, function () {
-          doneFn();
-        });
+          .children('td')
+          .children('div')
+          .slideUp(250, function() {
+            doneFn();
+          });
     },
   };
 }

--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -38,7 +38,7 @@ export default function requestViewController(
     localStorageService,
     RequestService,
     SystemService,
-    EventService
+    EventService,
 ) {
   $scope.request = undefined;
   $scope.complete = false;
@@ -184,7 +184,7 @@ export default function requestViewController(
     const requestSystem = SystemService.findSystem(
         namespace,
         $scope.request.system,
-        $scope.request.system_version
+        $scope.request.system_version,
     );
     if (requestSystem != undefined) {
       const commands = requestSystem.commands;
@@ -207,7 +207,7 @@ export default function requestViewController(
         $scope.request.metadata.system_display_name || $scope.request.system,
         $scope.request.system_version,
         $scope.request.instance_name,
-        'request'
+        'request',
     );
 
     if (RequestService.isComplete($scope.request)) {
@@ -240,7 +240,7 @@ export default function requestViewController(
     const system = SystemService.findSystem(
         $scope.request.namespace,
         $scope.request.system,
-        $scope.request.system_version
+        $scope.request.system_version,
     );
     $scope.instanceStatus = _.find(system.instances, {
       name: $scope.request.instance_name,

--- a/src/ui/src/js/controllers/system_index.js
+++ b/src/ui/src/js/controllers/system_index.js
@@ -19,7 +19,7 @@ export default function systemIndexController(
     $rootScope,
     localStorageService,
     UtilityService,
-    DTOptionsBuilder
+    DTOptionsBuilder,
 ) {
   $scope.setWindowTitle();
 
@@ -29,7 +29,7 @@ export default function systemIndexController(
       .withOption('autoWidth', false)
       .withOption(
           'pageLength',
-          localStorageService.get('_system_index_length') || 10
+          localStorageService.get('_system_index_length') || 10,
       )
       .withOption('order', [
         [0, 'asc'],

--- a/src/ui/src/js/controllers/system_index.js
+++ b/src/ui/src/js/controllers/system_index.js
@@ -1,9 +1,9 @@
 systemIndexController.$inject = [
-  "$scope",
-  "$rootScope",
-  "localStorageService",
-  "UtilityService",
-  "DTOptionsBuilder",
+  '$scope',
+  '$rootScope',
+  'localStorageService',
+  'UtilityService',
+  'DTOptionsBuilder',
 ];
 
 /**
@@ -12,81 +12,82 @@ systemIndexController.$inject = [
  * @param  {Object} $rootScope     Angular's $rootScope object.
  * @param  {Object} localStorageService  Storage service
  * @param  {Object} UtilityService Beer-Garden's utility service.
+ * @param   {Object} DTOptionsBuilder  Options builder
  */
 export default function systemIndexController(
-  $scope,
-  $rootScope,
-  localStorageService,
-  UtilityService,
-  DTOptionsBuilder
+    $scope,
+    $rootScope,
+    localStorageService,
+    UtilityService,
+    DTOptionsBuilder
 ) {
   $scope.setWindowTitle();
 
   $scope.util = UtilityService;
 
   $scope.dtOptions = DTOptionsBuilder.newOptions()
-    .withOption("autoWidth", false)
-    .withOption(
-      "pageLength",
-      localStorageService.get("_system_index_length") || 10
-    )
-    .withOption("order", [
-      [0, "asc"],
-      [1, "asc"],
-      [2, "asc"],
-      [3, "asc"],
-    ])
-    .withLightColumnFilter({
-      0: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Namespace Filter" },
-      },
-      1: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "System Filter" },
-      },
-      2: {
-        html: "input",
-        type: "text",
-        attr: { class: "form-inline form-control", title: "Version Filter" },
-      },
-      3: {
-        html: "input",
-        type: "text",
-        attr: {
-          class: "form-inline form-control",
-          title: "Description Filter",
+      .withOption('autoWidth', false)
+      .withOption(
+          'pageLength',
+          localStorageService.get('_system_index_length') || 10
+      )
+      .withOption('order', [
+        [0, 'asc'],
+        [1, 'asc'],
+        [2, 'asc'],
+        [3, 'asc'],
+      ])
+      .withLightColumnFilter({
+        0: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'Namespace Filter'},
         },
-      },
-      4: {
-        html: "input",
-        type: "number",
-        attr: { class: "form-inline form-control", title: "Commands Filter" },
-      },
-      5: {
-        html: "input",
-        type: "number",
-        attr: { class: "form-inline form-control", title: "Instances Filter" },
-      },
-    })
-    .withBootstrap();
+        1: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'System Filter'},
+        },
+        2: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'Version Filter'},
+        },
+        3: {
+          html: 'input',
+          type: 'text',
+          attr: {
+            class: 'form-inline form-control',
+            title: 'Description Filter',
+          },
+        },
+        4: {
+          html: 'input',
+          type: 'number',
+          attr: {class: 'form-inline form-control', title: 'Commands Filter'},
+        },
+        5: {
+          html: 'input',
+          type: 'number',
+          attr: {class: 'form-inline form-control', title: 'Instances Filter'},
+        },
+      })
+      .withBootstrap();
 
-  $scope.instanceCreated = function (_instance) {
+  $scope.instanceCreated = function(_instance) {
     $scope.dtInstance = _instance;
 
-    $("#systemIndexTable").on("length.dt", (event, settings, len) => {
-      localStorageService.set("_system_index_length", len);
+    $('#systemIndexTable').on('length.dt', (event, settings, len) => {
+      localStorageService.set('_system_index_length', len);
     });
   };
 
-  $scope.successCallback = function (response) {
+  $scope.successCallback = function(response) {
     $scope.response = response;
     $scope.data = response.data;
   };
 
-  $scope.failureCallback = function (response) {
+  $scope.failureCallback = function(response) {
     $scope.response = response;
     $scope.data = {};
   };

--- a/src/ui/src/js/directives/custom_on_change.js
+++ b/src/ui/src/js/directives/custom_on_change.js
@@ -1,10 +1,10 @@
 export default function customOnChangeDirective() {
   return {
-    restrict: "A",
-    link: function (scope, element, attrs) {
-      let onChangeFunc = scope.$eval(attrs.customOnChange);
-      element.bind("change", onChangeFunc);
-      element.on("$destroy", function () {
+    restrict: 'A',
+    link: function(scope, element, attrs) {
+      const onChangeFunc = scope.$eval(attrs.customOnChange);
+      element.bind('change', onChangeFunc);
+      element.on('$destroy', function() {
         element.off();
       });
     },

--- a/src/ui/src/js/directives/fetch_data.js
+++ b/src/ui/src/js/directives/fetch_data.js
@@ -1,70 +1,70 @@
-import _ from "lodash";
-import template from "../../templates/fetch_data.html";
-import { responseState } from "../services/utility_service.js";
+import _ from 'lodash';
+import template from '../../templates/fetch_data.html';
+import {responseState} from '../services/utility_service.js';
 
-fetchDataDirective.$inject = ["$timeout", "ErrorService"];
+fetchDataDirective.$inject = ['$timeout', 'ErrorService'];
 
 export default function fetchDataDirective($timeout, ErrorService) {
   return {
-    restrict: "E",
+    restrict: 'E',
     scope: {
-      closeable: "@?",
-      delay: "@?",
-      hide: "@?",
-      response: "=",
+      closeable: '@?',
+      delay: '@?',
+      hide: '@?',
+      response: '=',
     },
     template: template,
-    link: function (scope, element, attrs) {
+    link: function(scope, element, attrs) {
       // Do a little translation of the real state
-      scope.responseState = function (response) {
-        let realState = responseState(response);
+      scope.responseState = function(response) {
+        const realState = responseState(response);
         if (
-          (_.includes(scope.hide, "loading") && realState === "loading") ||
-          (_.includes(scope.hide, "empty") && realState === "empty")
+          (_.includes(scope.hide, 'loading') && realState === 'loading') ||
+          (_.includes(scope.hide, 'empty') && realState === 'empty')
         ) {
-          return "success";
+          return 'success';
         }
         return realState;
       };
 
-      scope.close = function () {
+      scope.close = function() {
         scope.response.status = 200;
       };
 
-      scope.getErrors = function (response) {
+      scope.getErrors = function(response) {
         let specific;
         let statusCode;
 
         // Do some simple translation to add extra items based on the url
-        let url = _.get(response, "config.url");
-        if (_.includes(url, "system")) {
-          specific = "system";
-        } else if (_.includes(url, "requests/")) {
-          specific = "request";
+        const url = _.get(response, 'config.url');
+        if (_.includes(url, 'system')) {
+          specific = 'system';
+        } else if (_.includes(url, 'requests/')) {
+          specific = 'request';
         }
 
-        if (scope.responseState(response) === "empty") {
-          statusCode = "404";
-        } else if (scope.responseState(response) === "error") {
+        if (scope.responseState(response) === 'empty') {
+          statusCode = '404';
+        } else if (scope.responseState(response) === 'error') {
           statusCode = response.status;
         }
 
         return ErrorService.getErrors(specific, statusCode);
       };
 
-      scope.errorGroup = function () {
+      scope.errorGroup = function() {
         // There are some cases where we 'fake' a failure without actually
         // making a request. In those cases we'll just pass the error group.
         if (scope.response.errorGroup) {
           return scope.response.errorGroup;
         }
-        if (_.includes(scope.response.config.url, "system")) {
-          return "system";
+        if (_.includes(scope.response.config.url, 'system')) {
+          return 'system';
         }
       };
 
-      scope.errorMessage = function () {
-        return _.get(scope.response.data, "message", scope.response.data);
+      scope.errorMessage = function() {
+        return _.get(scope.response.data, 'message', scope.response.data);
       };
 
       const delay = _.isUndefined(scope.delay) ? 0.25 : parseFloat(scope.delay);

--- a/src/ui/src/js/directives/system_status.js
+++ b/src/ui/src/js/directives/system_status.js
@@ -1,4 +1,4 @@
-import template from "../../templates/system_status.html";
+import template from '../../templates/system_status.html';
 
 /**
  * systemStatusDirective - Directive for rendering system status.
@@ -6,31 +6,31 @@ import template from "../../templates/system_status.html";
  */
 export default function systemStatusDirective() {
   return {
-    restrict: "E",
+    restrict: 'E',
     scope: {
-      status: "=target",
+      status: '=target',
     },
     template: template,
-    link: function (scope, element, attrs) {
-      scope.$watch("status", function () {
+    link: function(scope, element, attrs) {
+      scope.$watch('status', function() {
         switch (scope.status) {
-          case "RUNNING":
-            scope.labelClass = "label-success";
+          case 'RUNNING':
+            scope.labelClass = 'label-success';
             break;
-          case "STOPPING":
-          case "UNRESPONSIVE":
-            scope.labelClass = "label-warning";
+          case 'STOPPING':
+          case 'UNRESPONSIVE':
+            scope.labelClass = 'label-warning';
             break;
-          case "STARTING":
-          case "INITIALIZING":
-            scope.labelClass = "label-info";
+          case 'STARTING':
+          case 'INITIALIZING':
+            scope.labelClass = 'label-info';
             break;
-          case "RELOADING":
-            scope.labelClass = "label-primary";
+          case 'RELOADING':
+            scope.labelClass = 'label-primary';
             break;
-          case "DEAD":
-          case "STOPPED":
-            scope.labelClass = "label-danger";
+          case 'DEAD':
+          case 'STOPPED':
+            scope.labelClass = 'label-danger';
             break;
         }
       });

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -1,28 +1,28 @@
-import $ from "jquery";
-import _ from "lodash";
-import { responseState } from "./services/utility_service.js";
+import $ from 'jquery';
+import _ from 'lodash';
+import {responseState} from './services/utility_service.js';
 
-import loginTemplate from "../templates/login.html";
+import loginTemplate from '../templates/login.html';
 
 window.$ = $;
 window._ = _;
 
 appRun.$inject = [
-  "$rootScope",
-  "$state",
-  "$stateParams",
-  "$http",
-  "$q",
-  "$uibModal",
-  "$transitions",
-  "$interval",
-  "localStorageService",
-  "UtilityService",
-  "SystemService",
-  "UserService",
-  "TokenService",
-  "RoleService",
-  "EventService",
+  '$rootScope',
+  '$state',
+  '$stateParams',
+  '$http',
+  '$q',
+  '$uibModal',
+  '$transitions',
+  '$interval',
+  'localStorageService',
+  'UtilityService',
+  'SystemService',
+  'UserService',
+  'TokenService',
+  'RoleService',
+  'EventService',
 ];
 
 /**
@@ -44,21 +44,21 @@ appRun.$inject = [
  * @param  {Object} EventService         Service for Event information.
  */
 export default function appRun(
-  $rootScope,
-  $state,
-  $stateParams,
-  $http,
-  $q,
-  $uibModal,
-  $transitions,
-  $interval,
-  localStorageService,
-  UtilityService,
-  SystemService,
-  UserService,
-  TokenService,
-  RoleService,
-  EventService
+    $rootScope,
+    $state,
+    $stateParams,
+    $http,
+    $q,
+    $uibModal,
+    $transitions,
+    $interval,
+    localStorageService,
+    UtilityService,
+    SystemService,
+    UserService,
+    TokenService,
+    RoleService,
+    EventService
 ) {
   $rootScope.$state = $state;
   $rootScope.$stateParams = $stateParams;
@@ -67,7 +67,7 @@ export default function appRun(
   $rootScope.loginInfo = {};
 
   // Change this to point to the Brew-View backend if it's at another location
-  $rootScope.apiBaseUrl = "";
+  $rootScope.apiBaseUrl = '';
 
   $rootScope.config = {};
 
@@ -76,41 +76,41 @@ export default function appRun(
     slate: false,
   };
 
-  $rootScope.menu_page = "main";
+  $rootScope.menu_page = 'main';
 
   $rootScope.responseState = responseState;
 
   $rootScope.getIcon = UtilityService.getIcon;
 
-  $rootScope.loadUser = function (token) {
+  $rootScope.loadUser = function(token) {
     $rootScope.userPromise = UserService.loadUser(token).then(
-      (response) => {
+        (response) => {
         // Angular doesn't do a deep watch here, so make sure we calculate
         // and set the permissions before setting $rootScope.user
-        const user = response.data;
+          const user = response.data;
 
-        // coalescePermissions [0] is roles, [1] is permissions
-        user.permissions = RoleService.coalescePermissions(user.roles)[1];
+          // coalescePermissions [0] is roles, [1] is permissions
+          user.permissions = RoleService.coalescePermissions(user.roles)[1];
 
-        // If user is logged in, change to their default theme selection
-        let theme;
-        if (user.id) {
-          theme = _.get(user, "preferences.theme", "default");
-        } else {
-          theme = localStorageService.get("currentTheme") || "default";
+          // If user is logged in, change to their default theme selection
+          let theme;
+          if (user.id) {
+            theme = _.get(user, 'preferences.theme', 'default');
+          } else {
+            theme = localStorageService.get('currentTheme') || 'default';
+          }
+          $rootScope.changeTheme(theme, false);
+
+          $rootScope.user = user;
+        },
+        (response) => {
+          return $q.reject(response);
         }
-        $rootScope.changeTheme(theme, false);
-
-        $rootScope.user = user;
-      },
-      (response) => {
-        return $q.reject(response);
-      }
     );
     return $rootScope.userPromise;
   };
 
-  $rootScope.changeUser = function (token) {
+  $rootScope.changeUser = function(token) {
     // // We need to reload systems as those permisisons could have changed
     // SystemService.loadSystems();
 
@@ -119,7 +119,7 @@ export default function appRun(
     });
   };
 
-  $rootScope.initialLoad = function () {
+  $rootScope.initialLoad = function() {
     // Very first thing is to load up a token if one exists
     const token = TokenService.getToken();
     const refreshToken = TokenService.getRefresh();
@@ -138,7 +138,7 @@ export default function appRun(
 
     // Load theme from local storage
     // REMOVE THIS ONCE THE rootScope.loadUser CALL BELOW IS ENABLED
-    const theme = localStorageService.get("currentTheme") || "default";
+    const theme = localStorageService.get('currentTheme') || 'default';
     $rootScope.changeTheme(theme, false);
 
     // $rootScope.loadUser(token).catch(
@@ -151,17 +151,17 @@ export default function appRun(
     // );
   };
 
-  $rootScope.hasPermission = function (user, permissions) {
+  $rootScope.hasPermission = function(user, permissions) {
     if (!$rootScope.config.authEnabled) return true;
     if (_.isUndefined(user)) return false;
-    if (_.includes(user.permissions, "bg-all")) return true;
+    if (_.includes(user.permissions, 'bg-all')) return true;
 
     // This makes it possible to pass an array or a single string
     return _.intersection(user.permissions, _.castArray(permissions)).length;
   };
 
-  $rootScope.changeTheme = function (theme, sendUpdate) {
-    localStorageService.set("currentTheme", theme);
+  $rootScope.changeTheme = function(theme, sendUpdate) {
+    localStorageService.set('currentTheme', theme);
     for (const key of Object.keys($rootScope.themes)) {
       $rootScope.themes[key] = key == theme;
     }
@@ -171,27 +171,27 @@ export default function appRun(
     }
   };
 
-  $rootScope.authEnabled = function () {
+  $rootScope.authEnabled = function() {
     return $rootScope.config.authEnabled;
   };
 
-  $rootScope.isUser = function (user) {
-    return user && user.username !== "anonymous";
+  $rootScope.isUser = function(user) {
+    return user && user.username !== 'anonymous';
   };
 
-  $rootScope.doLogin = function () {
+  $rootScope.doLogin = function() {
     if (!loginModal) {
       loginModal = $uibModal.open({
-        controller: "LoginController",
-        size: "sm",
+        controller: 'LoginController',
+        size: 'sm',
         template: loginTemplate,
       });
       loginModal.result.then(
-        () => {
-          $rootScope.changeUser(TokenService.getToken());
-          location.reload();
-        },
-        _.noop // Prevents annoying console log messages
+          () => {
+            $rootScope.changeUser(TokenService.getToken());
+            location.reload();
+          },
+          _.noop // Prevents annoying console log messages
       );
       loginModal.closed.then(() => {
         loginModal = undefined;
@@ -203,7 +203,7 @@ export default function appRun(
     return loginModal;
   };
 
-  $rootScope.doLogout = function () {
+  $rootScope.doLogout = function() {
     TokenService.clearToken();
     TokenService.clearRefresh();
 
@@ -211,25 +211,25 @@ export default function appRun(
     location.reload();
   };
 
-  $rootScope.setWindowTitle = function (...titleParts) {
+  $rootScope.setWindowTitle = function(...titleParts) {
     titleParts.push($rootScope.config.applicationName);
-    $rootScope.title = _.join(titleParts, " - ");
+    $rootScope.title = _.join(titleParts, ' - ');
   };
 
-  $transitions.onSuccess({ to: "base" }, () => {
-    $state.go("base.systems");
+  $transitions.onSuccess({to: 'base'}, () => {
+    $state.go('base.systems');
   });
 
-  $rootScope.setMenuPage = function (page) {
+  $rootScope.setMenuPage = function(page) {
     $rootScope.menu_page = page;
   };
 
-  $rootScope.checkMenuPage = function (page) {
+  $rootScope.checkMenuPage = function(page) {
     return $rootScope.menu_page == page;
   };
 
   function upsertSystem(system) {
-    const index = _.findIndex($rootScope.systems, { id: system.id });
+    const index = _.findIndex($rootScope.systems, {id: system.id});
 
     if (index == -1) {
       $rootScope.systems.push(system);
@@ -239,7 +239,7 @@ export default function appRun(
   }
 
   function removeSystem(system) {
-    const index = _.findIndex($rootScope.systems, { id: system.id });
+    const index = _.findIndex($rootScope.systems, {id: system.id});
 
     if (index != -1) {
       $rootScope.systems.splice(index, 1);
@@ -248,7 +248,7 @@ export default function appRun(
 
   function updateInstance(instance) {
     _.forEach($rootScope.systems, (sys) => {
-      const index = _.findIndex(sys.instances, { id: instance.id });
+      const index = _.findIndex(sys.instances, {id: instance.id});
 
       if (index != -1) {
         sys.instances.splice(index, 1, instance);
@@ -259,17 +259,17 @@ export default function appRun(
     });
   }
 
-  EventService.addCallback("global_systems", (event) => {
-    if (["SYSTEM_CREATED", "SYSTEM_UPDATED"].includes(event.name)) {
+  EventService.addCallback('global_systems', (event) => {
+    if (['SYSTEM_CREATED', 'SYSTEM_UPDATED'].includes(event.name)) {
       upsertSystem(event.payload);
-    } else if (event.name == "SYSTEM_REMOVED") {
+    } else if (event.name == 'SYSTEM_REMOVED') {
       removeSystem(event.payload);
-    } else if (event.name.startsWith("INSTANCE")) {
+    } else if (event.name.startsWith('INSTANCE')) {
       updateInstance(event.payload);
     }
   });
 
-  $interval(function () {
+  $interval(function() {
     EventService.connect(TokenService.getToken());
   }, 5000);
 

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -58,7 +58,7 @@ export default function appRun(
     UserService,
     TokenService,
     RoleService,
-    EventService
+    EventService,
 ) {
   $rootScope.$state = $state;
   $rootScope.$stateParams = $stateParams;
@@ -105,7 +105,7 @@ export default function appRun(
         },
         (response) => {
           return $q.reject(response);
-        }
+        },
     );
     return $rootScope.userPromise;
   };
@@ -191,7 +191,7 @@ export default function appRun(
             $rootScope.changeUser(TokenService.getToken());
             location.reload();
           },
-          _.noop // Prevents annoying console log messages
+          _.noop, // Prevents annoying console log messages
       );
       loginModal.closed.then(() => {
         loginModal = undefined;

--- a/src/ui/src/js/services/admin_service.js
+++ b/src/ui/src/js/services/admin_service.js
@@ -1,4 +1,4 @@
-adminService.$inject = ["$http"];
+adminService.$inject = ['$http'];
 
 /**
  * adminService - Service for interacting with the admin API.
@@ -8,7 +8,7 @@ adminService.$inject = ["$http"];
 export default function adminService($http) {
   return {
     rescan: () => {
-      return $http.patch("api/v1/admin/", { operation: "rescan" });
+      return $http.patch('api/v1/admin/', {operation: 'rescan'});
     },
   };
 }

--- a/src/ui/src/js/services/command_service.js
+++ b/src/ui/src/js/services/command_service.js
@@ -1,15 +1,16 @@
-commandService.$inject = ["$http", "$rootScope"];
+commandService.$inject = ['$http', '$rootScope'];
 
 /**
  * commandService - Service for interacting with the command API.
  * @param  {$http} $http           Angular's $http Object.
  * @param  {$rootScope} $rootScope Angular's $rootScope Object.
+ * @param  {SystemService} SystemService  System service
  * @return {Object}               Service for interacting with the command API.
  */
 export default function commandService($http, $rootScope, SystemService) {
   return {
     getCommands: (params) => {
-      return $http.get("api/v1/commands", { params: params });
+      return $http.get('api/v1/commands', {params: params});
     },
   };
 }

--- a/src/ui/src/js/services/error_service.js
+++ b/src/ui/src/js/services/error_service.js
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import _ from 'lodash';
 
 /**
  * errorService - Service for displaying errors
@@ -9,68 +9,68 @@ export default function errorService() {
     401: {
       common: [
         {
-          problem: "Not Logged In",
+          problem: 'Not Logged In',
           description:
-            "You're not logged in and anonymous users aren't able to view " +
-            "this data or perform this action.",
-          resolution: "Log in using the button at the top of the screen.",
+            'You\'re not logged in and anonymous users aren\'t able to view ' +
+            'this data or perform this action.',
+          resolution: 'Log in using the button at the top of the screen.',
         },
       ],
     },
     403: {
       common: [
         {
-          problem: "Insufficient Permissions",
+          problem: 'Insufficient Permissions',
           description:
-            "You don't have the necessary permission to view this data or " +
-            "perform this action.",
+            'You don\'t have the necessary permission to view this data or ' +
+            'perform this action.',
           resolution:
-            "Contact your administrator and request to be given permission.",
+            'Contact your administrator and request to be given permission.',
         },
         {
-          problem: "Signature verification failed",
+          problem: 'Signature verification failed',
           description:
-            "The signature of the token used in the request couldn't be " +
-            "validated by the server.",
+            'The signature of the token used in the request couldn\'t be ' +
+            'validated by the server.',
           resolution:
-            "Log out (if currently logged in) and log in again to generate " +
-            "a new token.",
+            'Log out (if currently logged in) and log in again to generate ' +
+            'a new token.',
         },
       ],
     },
     404: {
       common: [
         {
-          problem: "No plugins",
+          problem: 'No plugins',
           description:
-            "If no one has developed any plugins then there won't be " +
-            "anything here. You'll need to build and deploy some plugins.",
-          resolution: "Develop a Plugin",
+            'If no one has developed any plugins then there won\'t be ' +
+            'anything here. You\'ll need to build and deploy some plugins.',
+          resolution: 'Develop a Plugin',
         },
         {
-          problem: "Wrong identifier",
+          problem: 'Wrong identifier',
           description:
-            "The identifiers for the resource may be off. For example, a " +
-            "system bookmark may be for an old version that's been removed.",
-          resolution: "Double-check that all identifiers are correct",
+            'The identifiers for the resource may be off. For example, a ' +
+            'system bookmark may be for an old version that\'s been removed.',
+          resolution: 'Double-check that all identifiers are correct',
         },
       ],
       request: [
         {
-          problem: "Request was removed",
+          problem: 'Request was removed',
           description:
-            "Beergarden can be set to remove requests after several " +
-            "minutes, so this request may have been removed.",
-          resolution: "Go back to the list of all requests",
+            'Beergarden can be set to remove requests after several ' +
+            'minutes, so this request may have been removed.',
+          resolution: 'Go back to the list of all requests',
         },
       ],
     },
     503: {
       common: [
         {
-          problem: "Bartender Stopped",
-          description: "Bartender is not running for some reason.",
-          resolution: "Have your system administrator start Bartender.",
+          problem: 'Bartender Stopped',
+          description: 'Bartender is not running for some reason.',
+          resolution: 'Have your system administrator start Bartender.',
         },
       ],
     },
@@ -81,8 +81,8 @@ export default function errorService() {
       if (!_.has(errorMap, statusCode)) return [];
 
       return _.concat(
-        _.get(errorMap[statusCode], specific, []),
-        _.get(errorMap[statusCode], "common", [])
+          _.get(errorMap[statusCode], specific, []),
+          _.get(errorMap[statusCode], 'common', [])
       );
     },
   };

--- a/src/ui/src/js/services/error_service.js
+++ b/src/ui/src/js/services/error_service.js
@@ -82,7 +82,7 @@ export default function errorService() {
 
       return _.concat(
           _.get(errorMap[statusCode], specific, []),
-          _.get(errorMap[statusCode], 'common', [])
+          _.get(errorMap[statusCode], 'common', []),
       );
     },
   };

--- a/src/ui/src/js/services/event_service.js
+++ b/src/ui/src/js/services/event_service.js
@@ -1,4 +1,4 @@
-eventService.$inject = ["TokenService"];
+eventService.$inject = ['TokenService'];
 
 /**
  * eventService - Service for getting systems from the API.
@@ -7,12 +7,12 @@ eventService.$inject = ["TokenService"];
  */
 export default function eventService(TokenService) {
   let socketConnection = undefined;
-  let messageCallbacks = {};
+  const messageCallbacks = {};
 
-  let onMessage = (message) => {
-    let event = JSON.parse(message.data);
+  const onMessage = (message) => {
+    const event = JSON.parse(message.data);
 
-    for (let callback of _.values(messageCallbacks)) {
+    for (const callback of _.values(messageCallbacks)) {
       callback(event);
     }
   };
@@ -31,13 +31,13 @@ export default function eventService(TokenService) {
         socketConnection.readyState == WebSocket.CLOSED
       ) {
         let eventUrl =
-          (window.location.protocol === "https:" ? "wss://" : "ws://") +
+          (window.location.protocol === 'https:' ? 'wss://' : 'ws://') +
           window.location.host +
           window.location.pathname +
           `api/v1/socket/events/`;
 
         if (token) {
-          eventUrl += "?token=" + token;
+          eventUrl += '?token=' + token;
         }
 
         socketConnection = new WebSocket(eventUrl);

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -1,4 +1,4 @@
-gardenService.$inject = ["$http"];
+gardenService.$inject = ['$http'];
 
 /**
  * gardenService - Service for interacting with the garden API.
@@ -6,77 +6,78 @@ gardenService.$inject = ["$http"];
  * @return {Object}      Service for interacting with the garden API.
  */
 export default function gardenService($http) {
-  let GardenService = {};
+  const GardenService = {};
 
-  GardenService.getGardens = function () {
-    return $http.get("api/v1/gardens/");
+  GardenService.getGardens = function() {
+    return $http.get('api/v1/gardens/');
   };
 
-  GardenService.getGarden = function (name) {
-    return $http.get("api/v1/gardens/" + encodeURIComponent(name));
+  GardenService.getGarden = function(name) {
+    return $http.get('api/v1/gardens/' + encodeURIComponent(name));
   };
 
-  GardenService.createGarden = function (garden) {
-    return $http.post("api/v1/gardens", garden);
+  GardenService.createGarden = function(garden) {
+    return $http.post('api/v1/gardens', garden);
   };
 
-  GardenService.updateGardenConfig = function (garden) {
-    return $http.patch("api/v1/gardens/" + encodeURIComponent(garden.name), {
-      operation: "config",
-      path: "",
+  GardenService.updateGardenConfig = function(garden) {
+    return $http.patch('api/v1/gardens/' + encodeURIComponent(garden.name), {
+      operation: 'config',
+      path: '',
       value: garden,
     });
   };
 
-  GardenService.syncGardens = function () {
-    return $http.patch("api/v1/gardens", {
-      operation: "sync",
-      path: "",
-      value: "",
+  GardenService.syncGardens = function() {
+    return $http.patch('api/v1/gardens', {
+      operation: 'sync',
+      path: '',
+      value: '',
     });
   };
 
-  GardenService.syncGarden = function (name) {
-    return $http.patch("api/v1/gardens/" + encodeURIComponent(name), {
-      operation: "sync",
-      path: "",
-      value: "",
+  GardenService.syncGarden = function(name) {
+    return $http.patch('api/v1/gardens/' + encodeURIComponent(name), {
+      operation: 'sync',
+      path: '',
+      value: '',
     });
   };
 
-  GardenService.deleteGarden = function (name) {
-    return $http.delete("api/v1/gardens/" + encodeURIComponent(name));
+  GardenService.deleteGarden = function(name) {
+    return $http.delete('api/v1/gardens/' + encodeURIComponent(name));
   };
 
-  GardenService.serverModelToForm = function (model) {
-    var values = {};
-    var stomp_headers = [];
-    values["connection_type"] = model["connection_type"];
+  GardenService.serverModelToForm = function(model) {
+    const values = {};
+    const stompHeaders = [];
+    values['connection_type'] = model['connection_type'];
     if (
-      model.hasOwnProperty("connection_params") &&
+      model.hasOwnProperty('connection_params') &&
       model.connection_params != null
     ) {
-      for (var parameter of Object.keys(model["connection_params"])) {
-        if (parameter == "stomp_headers") {
-          for (var key in model["connection_params"][parameter]) {
-            stomp_headers[stomp_headers.length] = {
+      for (const parameter of Object.keys(model['connection_params'])) {
+        if (parameter == 'stomp_headers') {
+          // eslint-disable-next-line guard-for-in
+          for (const key in model['connection_params'][parameter]) {
+            stompHeaders[stompHeaders.length] = {
               key: key,
-              value: model["connection_params"][parameter][key],
+              value: model['connection_params'][parameter][key],
             };
           }
-          values[parameter] = stomp_headers;
+          values[parameter] = stompHeaders;
         } else {
           // Recursively remove null/empty values from json payload
-          var parameter_value = (function filter(obj) {
+          const parameterValue = (function filter(obj) {
             Object.entries(obj).forEach(
-              ([key, val]) =>
-                (val && typeof val === "object" && filter(val)) ||
-                ((val === null || val === "") && delete obj[key])
+                ([key, val]) =>
+                  (val && typeof val === 'object' && filter(val)) ||
+                ((val === null || val === '') && delete obj[key])
             );
             return obj;
           })(model.connection_params[parameter]);
 
-          values[parameter] = parameter_value;
+          values[parameter] = parameterValue;
         }
       }
     }
@@ -84,176 +85,186 @@ export default function gardenService($http) {
     return values;
   };
 
-  GardenService.formToServerModel = function (model, form) {
-    model["connection_type"] = form["connection_type"];
-    model["connection_params"] = {};
-    var stomp_headers = {};
-    for (var field of Object.keys(form)) {
-      if (field == "stomp_headers") {
-        for (var i in form[field]) {
-          stomp_headers[form[field][i]["key"]] = form[field][i]["value"];
+  GardenService.formToServerModel = function(model, form) {
+    model['connection_type'] = form['connection_type'];
+    model['connection_params'] = {};
+    const stompHeaders = {};
+    for (const field of Object.keys(form)) {
+      if (field == 'stomp_headers') {
+        // eslint-disable-next-line guard-for-in
+        for (const i in form[field]) {
+          stompHeaders[form[field][i]['key']] = form[field][i]['value'];
         }
-        model["connection_params"][field] = stomp_headers;
-      } else if (field != "connection_type") {
-        model["connection_params"][field] = form[field];
+        model['connection_params'][field] = stompHeaders;
+      } else if (field != 'connection_type') {
+        model['connection_params'][field] = form[field];
       }
     }
 
     return model;
   };
 
-  GardenService.CONNECTION_TYPES = ["HTTP", "STOMP"];
+  GardenService.CONNECTION_TYPES = ['HTTP', 'STOMP'];
 
   //  GardenService.stomp_header_array_to_dict = function(key, value){
   //    GardenService.
   //  }
 
   GardenService.SCHEMA = {
-    type: "object",
-    required: ["connection_type"],
+    type: 'object',
+    required: ['connection_type'],
     properties: {
       connection_type: {
-        title: "Connection Type",
+        title: 'Connection Type',
         description:
-          "The type of connection that is established for the Garden to receive requests and events",
-        type: "string",
+          'The type of connection that is established for the Garden to ' +
+          'receive requests and events',
+        type: 'string',
         enum: GardenService.CONNECTION_TYPES,
       },
       http: {
-        title: " ",
-        type: "object",
+        title: ' ',
+        type: 'object',
         properties: {
           name: {
-            title: "Garden Name",
+            title: 'Garden Name',
             description:
-              "This is the globally routing name that Beer Garden utilizes when routing requests and events",
-            type: "string",
+              'This is the globally routing name that Beer Garden utilizes ' +
+              'when routing requests and events',
+            type: 'string',
           },
           host: {
-            title: "Host Name",
-            description: "Beer-garden hostname",
-            type: "string",
+            title: 'Host Name',
+            description: 'Beer-garden hostname',
+            type: 'string',
             minLength: 1,
           },
           port: {
-            title: "Port",
-            description: "Beer-garden port",
-            type: "integer",
+            title: 'Port',
+            description: 'Beer-garden port',
+            type: 'integer',
             minLength: 1,
           },
           url_prefix: {
-            title: "URL Prefix",
+            title: 'URL Prefix',
             description:
-              "URL path that will be used as a prefix when communicating with Beer-garden. Useful if Beer-garden is running on a URL other than '/'.",
-            type: "string",
+              'URL path that will be used as a prefix when communicating ' +
+              'with Beer-garden. Useful if Beer-garden is running on a URL ' +
+              'other than \'/\'.',
+            type: 'string',
           },
           ca_cert: {
-            title: "CA Cert Path",
+            title: 'CA Cert Path',
             description:
-              "Path to certificate file containing the certificate of the authority that issued the Beer-garden server certificate",
-            type: "string",
+              'Path to certificate file containing the certificate of the ' +
+              'authority that issued the Beer-garden server certificate',
+            type: 'string',
           },
           ca_verify: {
-            title: "CA Cert Verify",
-            description: "Whether to verify Beer-garden server certificate",
-            type: "boolean",
+            title: 'CA Cert Verify',
+            description: 'Whether to verify Beer-garden server certificate',
+            type: 'boolean',
           },
           ssl: {
-            title: "SSL Enabled",
-            description: "Whether to connect with provided certifications",
-            type: "boolean",
+            title: 'SSL Enabled',
+            description: 'Whether to connect with provided certifications',
+            type: 'boolean',
           },
           client_cert: {
-            title: "Client Cert Path",
+            title: 'Client Cert Path',
             description:
-              "Path to client certificate to use when communicating with Beer-garden",
-            type: "string",
+              'Path to client certificate to use when communicating with ' +
+              'Beer-garden',
+            type: 'string',
           },
         },
       },
       stomp: {
-        title: " ",
-        type: "object",
+        title: ' ',
+        type: 'object',
         properties: {
           host: {
-            title: "Host Name",
-            description: "Beer-garden hostname",
-            type: "string",
+            title: 'Host Name',
+            description: 'Beer-garden hostname',
+            type: 'string',
             minLength: 1,
           },
           port: {
-            title: "Port",
-            description: "Beer-garden port",
-            type: "integer",
+            title: 'Port',
+            description: 'Beer-garden port',
+            type: 'integer',
             minLength: 1,
           },
           send_destination: {
-            title: "Send Destination",
-            description: "Destination queue where Stomp will send messages.",
-            type: "string",
+            title: 'Send Destination',
+            description: 'Destination queue where Stomp will send messages.',
+            type: 'string',
           },
           subscribe_destination: {
-            title: "Subscribe Destination",
+            title: 'Subscribe Destination',
             description:
-              "Destination queue where Stomp will listen for messages.",
-            type: "string",
+              'Destination queue where Stomp will listen for messages.',
+            type: 'string',
           },
           username: {
-            title: "Username",
-            description: "Username for Stomp connection.",
-            type: "string",
+            title: 'Username',
+            description: 'Username for Stomp connection.',
+            type: 'string',
           },
           password: {
-            title: "Password",
-            description: "Password for Stomp connection.",
-            type: "string",
+            title: 'Password',
+            description: 'Password for Stomp connection.',
+            type: 'string',
           },
           ssl: {
-            title: " ",
-            type: "object",
+            title: ' ',
+            type: 'object',
             properties: {
               use_ssl: {
-                title: "SSL Enabled",
-                description: "Whether to connect with provided certifications",
-                type: "boolean",
+                title: 'SSL Enabled',
+                description: 'Whether to connect with provided certifications',
+                type: 'boolean',
               },
               ca_cert: {
-                title: "CA Cert",
+                title: 'CA Cert',
                 description:
-                  "Path to certificate file containing the certificate of the authority that issued the message broker certificate",
-                type: "string",
+                  'Path to certificate file containing the certificate of ' +
+                  'the authority that issued the message broker certificate',
+                type: 'string',
               },
               client_cert: {
-                title: "Client Cert",
+                title: 'Client Cert',
                 description:
-                  "Path to client public certificate to use when communicating with the message broker",
-                type: "string",
+                  'Path to client public certificate to use when ' +
+                  'communicating with the message broker',
+                type: 'string',
               },
               client_key: {
-                title: "Client Key",
+                title: 'Client Key',
                 description:
-                  "Path to client private key to use when communicating with the message broker",
-                type: "string",
+                  'Path to client private key to use when communicating with ' +
+                  'the message broker',
+                type: 'string',
               },
             },
           },
           headers: {
-            title: "Headers",
-            description: "Headers to be sent with message",
-            type: "array",
+            title: 'Headers',
+            description: 'Headers to be sent with message',
+            type: 'array',
             items: {
-              title: " ",
-              type: "object",
+              title: ' ',
+              type: 'object',
               properties: {
                 key: {
-                  title: "Key",
-                  description: "",
-                  type: "string",
+                  title: 'Key',
+                  description: '',
+                  type: 'string',
                 },
                 value: {
-                  title: "Value",
-                  description: "",
-                  type: "string",
+                  title: 'Value',
+                  description: '',
+                  type: 'string',
                 },
               },
             },
@@ -265,38 +276,38 @@ export default function gardenService($http) {
 
   GardenService.FORM = [
     {
-      type: "fieldset",
-      items: ["connection_type"],
+      type: 'fieldset',
+      items: ['connection_type'],
     },
     {
-      type: "fieldset",
+      type: 'fieldset',
       items: [
         {
-          type: "tabs",
+          type: 'tabs',
           tabs: [
             {
-              title: "HTTP",
+              title: 'HTTP',
               items: [
-                "http.host",
-                "http.port",
-                "http.url_prefix",
-                "http.ssl",
-                "http.ca_cert",
-                "http.ca_verify",
-                "http.client_cert",
+                'http.host',
+                'http.port',
+                'http.url_prefix',
+                'http.ssl',
+                'http.ca_cert',
+                'http.ca_verify',
+                'http.client_cert',
               ],
             },
             {
-              title: "STOMP",
+              title: 'STOMP',
               items: [
-                "stomp.host",
-                "stomp.port",
-                "stomp.send_destination",
-                "stomp.subscribe_destination",
-                "stomp.username",
-                "stomp.password",
-                "stomp.ssl",
-                "stomp.headers",
+                'stomp.host',
+                'stomp.port',
+                'stomp.send_destination',
+                'stomp.subscribe_destination',
+                'stomp.username',
+                'stomp.password',
+                'stomp.ssl',
+                'stomp.headers',
               ],
             },
           ],
@@ -304,14 +315,14 @@ export default function gardenService($http) {
       ],
     },
     {
-      type: "section",
-      htmlClass: "row",
+      type: 'section',
+      htmlClass: 'row',
       items: [
         {
-          type: "submit",
-          style: "btn-primary w-100",
-          title: "Save Configurations",
-          htmlClass: "col-md-10",
+          type: 'submit',
+          style: 'btn-primary w-100',
+          title: 'Save Configurations',
+          htmlClass: 'col-md-10',
         },
       ],
     },

--- a/src/ui/src/js/services/instance_service.js
+++ b/src/ui/src/js/services/instance_service.js
@@ -1,4 +1,4 @@
-instanceService.$inject = ["$http"];
+instanceService.$inject = ['$http'];
 
 /**
  * instanceService - Service for interacting with the instance API.
@@ -8,23 +8,23 @@ instanceService.$inject = ["$http"];
 export default function instanceService($http) {
   return {
     startInstance: (instance) => {
-      return $http.patch("api/v1/instances/" + instance.id, {
-        operation: "start",
+      return $http.patch('api/v1/instances/' + instance.id, {
+        operation: 'start',
       });
     },
     stopInstance: (instance) => {
-      return $http.patch("api/v1/instances/" + instance.id, {
-        operation: "stop",
+      return $http.patch('api/v1/instances/' + instance.id, {
+        operation: 'stop',
       });
     },
     getInstance: (instanceId) => {
-      return $http.get("api/v1/instances/" + instanceId);
+      return $http.get('api/v1/instances/' + instanceId);
     },
-    getInstanceLogs: (instanceId, timeout, start_line, end_line) => {
-      return $http.get("api/v1/instances/" + instanceId + "/logs/", {
+    getInstanceLogs: (instanceId, timeout, startLine, endLine) => {
+      return $http.get('api/v1/instances/' + instanceId + '/logs/', {
         params: {
-          start_line: start_line,
-          end_line: end_line,
+          start_line: startLine,
+          end_line: endLine,
           timeout: timeout,
         },
       });

--- a/src/ui/src/js/services/job_service.js
+++ b/src/ui/src/js/services/job_service.js
@@ -1,4 +1,4 @@
-jobService.$inject = ["$http", "NamespaceService"];
+jobService.$inject = ['$http', 'NamespaceService'];
 
 /**
  * jobService - Service for getting jobs from the API.
@@ -7,104 +7,104 @@ jobService.$inject = ["$http", "NamespaceService"];
  * @return {Object}                   Object for interacting with the job API.
  */
 export default function jobService($http, NamespaceService) {
-  let JobService = {};
+  const JobService = {};
 
-  JobService.getJobs = function () {
-    return $http.get("api/v1/jobs");
+  JobService.getJobs = function() {
+    return $http.get('api/v1/jobs');
   };
 
-  JobService.getJob = function (id) {
-    return $http.get("api/v1/jobs/" + id);
+  JobService.getJob = function(id) {
+    return $http.get('api/v1/jobs/' + id);
   };
 
-  JobService.exportJobs = function () {
-    return $http.post("api/v1/export/jobs/");
+  JobService.exportJobs = function() {
+    return $http.post('api/v1/export/jobs/');
   };
 
-  JobService.importJobs = function (payload) {
-    return $http.post("api/v1/import/jobs/", payload);
+  JobService.importJobs = function(payload) {
+    return $http.post('api/v1/import/jobs/', payload);
   };
 
-  JobService.createJob = function (job) {
-    if (job["id"] == null) {
-      return $http.post("api/v1/jobs", job);
+  JobService.createJob = function(job) {
+    if (job['id'] == null) {
+      return $http.post('api/v1/jobs', job);
     }
 
     return JobService.updateJob(job);
   };
 
-  JobService.deleteJob = function (id) {
-    return $http.delete("api/v1/jobs/" + id);
+  JobService.deleteJob = function(id) {
+    return $http.delete('api/v1/jobs/' + id);
   };
 
-  JobService.patchJob = function (id, payload) {
-    return $http.patch("api/v1/jobs/" + id, payload);
+  JobService.patchJob = function(id, payload) {
+    return $http.patch('api/v1/jobs/' + id, payload);
   };
 
-  JobService.runAdHocJob = function (id, resetInterval) {
+  JobService.runAdHocJob = function(id, resetInterval) {
     // `resetInterval` ignored until API understands what to
     // do with it.
     return $http.post(`api/v1/jobs/${id}/execute`);
   };
 
-  JobService.updateJob = function (job) {
-    return JobService.patchJob(job["id"], {
+  JobService.updateJob = function(job) {
+    return JobService.patchJob(job['id'], {
       operations: [
         {
-          operation: "update",
-          path: "/job",
+          operation: 'update',
+          path: '/job',
           value: job,
         },
       ],
     });
   };
 
-  JobService.resumeJob = function (jobId) {
+  JobService.resumeJob = function(jobId) {
     return JobService.patchJob(jobId, {
       operations: [
         {
-          operation: "update",
-          path: "/status",
-          value: "RUNNING",
+          operation: 'update',
+          path: '/status',
+          value: 'RUNNING',
         },
       ],
     });
   };
 
-  JobService.pauseJob = function (jobId) {
+  JobService.pauseJob = function(jobId) {
     return JobService.patchJob(jobId, {
       operations: [
         {
-          operation: "update",
-          path: "/status",
-          value: "PAUSED",
+          operation: 'update',
+          path: '/status',
+          value: 'PAUSED',
         },
       ],
     });
   };
 
-  const getTrigger = function (triggerType, formModel) {
-    if (triggerType === "date") {
+  const getTrigger = function(triggerType, formModel) {
+    if (triggerType === 'date') {
       return {
-        run_date: formModel["run_date"],
-        timezone: formModel["date_timezone"],
+        run_date: formModel['run_date'],
+        timezone: formModel['date_timezone'],
       };
-    } else if (triggerType === "interval") {
+    } else if (triggerType === 'interval') {
       let weeks = 0;
       let minutes = 0;
       let hours = 0;
       let seconds = 0;
       let days = 0;
-      if (formModel["interval"] === "weeks") {
-        weeks = formModel["interval_num"];
-      } else if (formModel["interval"] === "minutes") {
-        minutes = formModel["interval_num"];
-      } else if (formModel["interval"] === "hours") {
-        hours = formModel["interval_num"];
-      } else if (formModel["interval"] === "seconds") {
-        seconds = formModel["interval_num"];
-      } else if (formModel["interval"] === "days") {
-        days = formModel["interval_num"];
+      if (formModel['interval'] === 'weeks') {
+        weeks = formModel['interval_num'];
+      } else if (formModel['interval'] === 'minutes') {
+        minutes = formModel['interval_num'];
+      } else if (formModel['interval'] === 'hours') {
+        hours = formModel['interval_num'];
+      } else if (formModel['interval'] === 'seconds') {
+        seconds = formModel['interval_num'];
+      } else if (formModel['interval'] === 'days') {
+        days = formModel['interval_num'];
       }
       return {
         weeks: weeks,
@@ -112,180 +112,180 @@ export default function jobService($http, NamespaceService) {
         hours: hours,
         seconds: seconds,
         days: days,
-        jitter: formModel["interval_jitter"],
-        start_date: formModel["interval_start_date"],
-        end_date: formModel["interval_end_date"],
-        timezone: formModel["interval_timezone"],
-        reschedule_on_finish: formModel["interval_reschedule_on_finish"],
+        jitter: formModel['interval_jitter'],
+        start_date: formModel['interval_start_date'],
+        end_date: formModel['interval_end_date'],
+        timezone: formModel['interval_timezone'],
+        reschedule_on_finish: formModel['interval_reschedule_on_finish'],
       };
-    } else if (triggerType === "file") {
+    } else if (triggerType === 'file') {
       return {
-        pattern: formModel["file_pattern"],
-        path: formModel["file_path"],
-        recursive: formModel["file_recursive"],
-        callbacks: formModel["file_callbacks"],
+        pattern: formModel['file_pattern'],
+        path: formModel['file_path'],
+        recursive: formModel['file_recursive'],
+        callbacks: formModel['file_callbacks'],
       };
     } else {
       return {
-        minute: formModel["minute"],
-        hour: formModel["hour"],
-        day: formModel["day"],
-        month: formModel["month"],
-        day_of_week: formModel["day_of_week"],
-        year: formModel["year"],
-        week: formModel["week"],
-        second: formModel["second"],
-        jitter: formModel["cron_jitter"],
-        start_date: formModel["cron_start_date"],
-        end_date: formModel["cron_end_date"],
-        timezone: formModel["cron_timezone"],
+        minute: formModel['minute'],
+        hour: formModel['hour'],
+        day: formModel['day'],
+        month: formModel['month'],
+        day_of_week: formModel['day_of_week'],
+        year: formModel['year'],
+        week: formModel['week'],
+        second: formModel['second'],
+        jitter: formModel['cron_jitter'],
+        start_date: formModel['cron_start_date'],
+        end_date: formModel['cron_end_date'],
+        timezone: formModel['cron_timezone'],
       };
     }
   };
 
-  JobService.serverModelToForm = function (job) {
-    let formModel = {};
+  JobService.serverModelToForm = function(job) {
+    const formModel = {};
 
-    formModel["name"] = job["name"];
-    formModel["misfire_grace_time"] = job["misfire_grace_time"];
-    formModel["trigger_type"] = job["trigger_type"];
-    formModel["coalesce"] = job["coalesce"];
-    formModel["max_instances"] = job["max_instances"];
-    formModel["timeout"] = job["timeout"];
-    formModel["id"] = job["id"] || null;
+    formModel['name'] = job['name'];
+    formModel['misfire_grace_time'] = job['misfire_grace_time'];
+    formModel['trigger_type'] = job['trigger_type'];
+    formModel['coalesce'] = job['coalesce'];
+    formModel['max_instances'] = job['max_instances'];
+    formModel['timeout'] = job['timeout'];
+    formModel['id'] = job['id'] || null;
 
-    if (job["trigger_type"] === "date") {
-      formModel["run_date"] = job["trigger"]["run_date"];
-      formModel["date_timezone"] = job["trigger"]["timezone"];
-    } else if (job["trigger_type"] === "interval") {
-      formModel["weeks"] = job["trigger"]["weeks"] || 0;
-      formModel["minutes"] = job["trigger"]["minutes"] || 0;
-      formModel["hours"] = job["trigger"]["hours"] || 0;
-      formModel["seconds"] = job["trigger"]["seconds"] || 0;
-      formModel["days"] = job["trigger"]["days"] || 0;
+    if (job['trigger_type'] === 'date') {
+      formModel['run_date'] = job['trigger']['run_date'];
+      formModel['date_timezone'] = job['trigger']['timezone'];
+    } else if (job['trigger_type'] === 'interval') {
+      formModel['weeks'] = job['trigger']['weeks'] || 0;
+      formModel['minutes'] = job['trigger']['minutes'] || 0;
+      formModel['hours'] = job['trigger']['hours'] || 0;
+      formModel['seconds'] = job['trigger']['seconds'] || 0;
+      formModel['days'] = job['trigger']['days'] || 0;
 
-      if (job["trigger"]["weeks"] != 0) {
-        formModel["interval"] = "weeks";
-        formModel["interval_num"] = job["trigger"]["weeks"];
-      } else if (job["trigger"]["minutes"] != 0) {
-        formModel["interval"] = "minutes";
-        formModel["interval_num"] = job["trigger"]["minutes"];
-      } else if (job["trigger"]["hours"] != 0) {
-        formModel["interval"] = "hours";
-        formModel["interval_num"] = job["trigger"]["hours"];
-      } else if (job["trigger"]["seconds"] != 0) {
-        formModel["interval"] = "seconds";
-        formModel["interval_num"] = job["trigger"]["seconds"];
-      } else if (job["trigger"]["days"] != 0) {
-        formModel["interval"] = "days";
-        formModel["interval_num"] = job["trigger"]["days"];
+      if (job['trigger']['weeks'] != 0) {
+        formModel['interval'] = 'weeks';
+        formModel['interval_num'] = job['trigger']['weeks'];
+      } else if (job['trigger']['minutes'] != 0) {
+        formModel['interval'] = 'minutes';
+        formModel['interval_num'] = job['trigger']['minutes'];
+      } else if (job['trigger']['hours'] != 0) {
+        formModel['interval'] = 'hours';
+        formModel['interval_num'] = job['trigger']['hours'];
+      } else if (job['trigger']['seconds'] != 0) {
+        formModel['interval'] = 'seconds';
+        formModel['interval_num'] = job['trigger']['seconds'];
+      } else if (job['trigger']['days'] != 0) {
+        formModel['interval'] = 'days';
+        formModel['interval_num'] = job['trigger']['days'];
       }
 
-      formModel["interval_jitter"] = job["trigger"]["jitter"];
-      formModel["interval_start_date"] = job["trigger"]["start_date"];
-      formModel["interval_end_date"] = job["trigger"]["end_date"];
-      formModel["interval_timezone"] = job["trigger"]["timezone"];
-      formModel["interval_reschedule_on_finish"] =
-        job["trigger"]["reschedule_on_finish"];
-    } else if (job["trigger_type"] === "file") {
-      formModel["file_pattern"] = job["trigger"]["pattern"];
-      formModel["file_path"] = job["trigger"]["path"];
-      formModel["file_recursive"] = job["trigger"]["recursive"];
-      formModel["file_callbacks"] = job["trigger"]["callbacks"];
+      formModel['interval_jitter'] = job['trigger']['jitter'];
+      formModel['interval_start_date'] = job['trigger']['start_date'];
+      formModel['interval_end_date'] = job['trigger']['end_date'];
+      formModel['interval_timezone'] = job['trigger']['timezone'];
+      formModel['interval_reschedule_on_finish'] =
+        job['trigger']['reschedule_on_finish'];
+    } else if (job['trigger_type'] === 'file') {
+      formModel['file_pattern'] = job['trigger']['pattern'];
+      formModel['file_path'] = job['trigger']['path'];
+      formModel['file_recursive'] = job['trigger']['recursive'];
+      formModel['file_callbacks'] = job['trigger']['callbacks'];
     } else {
-      formModel["minute"] = job["trigger"]["minute"];
-      formModel["hour"] = job["trigger"]["hour"];
-      formModel["day"] = job["trigger"]["day"];
-      formModel["month"] = job["trigger"]["month"];
-      formModel["day_of_week"] = job["trigger"]["day_of_week"];
-      formModel["year"] = job["trigger"]["year"];
-      formModel["week"] = job["trigger"]["week"];
-      formModel["second"] = job["trigger"]["second"];
-      formModel["cron_jitter"] = job["trigger"]["jitter"];
-      formModel["cron_start_date"] = job["trigger"]["start_date"];
-      formModel["cron_end_date"] = job["trigger"]["end_date"];
-      formModel["cron_timezone"] = job["trigger"]["timezone"];
+      formModel['minute'] = job['trigger']['minute'];
+      formModel['hour'] = job['trigger']['hour'];
+      formModel['day'] = job['trigger']['day'];
+      formModel['month'] = job['trigger']['month'];
+      formModel['day_of_week'] = job['trigger']['day_of_week'];
+      formModel['year'] = job['trigger']['year'];
+      formModel['week'] = job['trigger']['week'];
+      formModel['second'] = job['trigger']['second'];
+      formModel['cron_jitter'] = job['trigger']['jitter'];
+      formModel['cron_start_date'] = job['trigger']['start_date'];
+      formModel['cron_end_date'] = job['trigger']['end_date'];
+      formModel['cron_timezone'] = job['trigger']['timezone'];
     }
 
     return formModel;
   };
 
-  JobService.formToServerModel = function (formModel, requestTemplate) {
-    let serviceModel = {};
-    serviceModel["name"] = formModel["name"];
-    serviceModel["misfire_grace_time"] = formModel["misfire_grace_time"];
-    serviceModel["trigger_type"] = formModel["trigger_type"];
-    serviceModel["trigger"] = getTrigger(formModel["trigger_type"], formModel);
-    serviceModel["request_template"] = requestTemplate;
-    serviceModel["coalesce"] = formModel["coalesce"];
-    serviceModel["max_instances"] = formModel["max_instances"];
-    serviceModel["timeout"] = formModel["timeout"];
-    serviceModel["id"] = formModel["id"] || null;
+  JobService.formToServerModel = function(formModel, requestTemplate) {
+    const serviceModel = {};
+    serviceModel['name'] = formModel['name'];
+    serviceModel['misfire_grace_time'] = formModel['misfire_grace_time'];
+    serviceModel['trigger_type'] = formModel['trigger_type'];
+    serviceModel['trigger'] = getTrigger(formModel['trigger_type'], formModel);
+    serviceModel['request_template'] = requestTemplate;
+    serviceModel['coalesce'] = formModel['coalesce'];
+    serviceModel['max_instances'] = formModel['max_instances'];
+    serviceModel['timeout'] = formModel['timeout'];
+    serviceModel['id'] = formModel['id'] || null;
     return serviceModel;
   };
 
-  JobService.TRIGGER_TYPES = ["cron", "date", "interval", "file"];
+  JobService.TRIGGER_TYPES = ['cron', 'date', 'interval', 'file'];
   JobService.CRON_KEYS = [
-    "minute",
-    "hour",
-    "day",
-    "month",
-    "day_of_week",
-    "year",
-    "week",
-    "second",
-    "cron_jitter",
-    "cron_start_date",
-    "cron_end_date",
-    "cron_timezone",
+    'minute',
+    'hour',
+    'day',
+    'month',
+    'day_of_week',
+    'year',
+    'week',
+    'second',
+    'cron_jitter',
+    'cron_start_date',
+    'cron_end_date',
+    'cron_timezone',
   ];
   JobService.INTERVAL_KEYS = [
-    "interval_num",
-    "interval",
-    "interval_start_date",
-    "interval_end_date",
-    "interval_timezone",
-    "interval_jitter",
-    "interval_reschedule_on_finish",
+    'interval_num',
+    'interval',
+    'interval_start_date',
+    'interval_end_date',
+    'interval_timezone',
+    'interval_jitter',
+    'interval_reschedule_on_finish',
   ];
-  JobService.DATE_KEYS = ["run_date", "date_timezone"];
+  JobService.DATE_KEYS = ['run_date', 'date_timezone'];
   JobService.FILE_KEYS = [
-    "file_pattern",
-    "file_path",
-    "file_recursive",
-    "file_callbacks",
+    'file_pattern',
+    'file_path',
+    'file_recursive',
+    'file_callbacks',
   ];
 
-  JobService.getRequiredKeys = function (triggerType) {
-    if (triggerType === "cron") {
-      let requiredKeys = [];
-      for (let key of JobService.CRON_KEYS) {
+  JobService.getRequiredKeys = function(triggerType) {
+    if (triggerType === 'cron') {
+      const requiredKeys = [];
+      for (const key of JobService.CRON_KEYS) {
         if (
           ![
-            "cron_start_date",
-            "cron_end_date",
-            "cron_timezone",
-            "cron_jitter",
+            'cron_start_date',
+            'cron_end_date',
+            'cron_timezone',
+            'cron_jitter',
           ].includes(key)
         ) {
           requiredKeys.push(key);
         }
       }
       return requiredKeys;
-    } else if (triggerType === "date") {
+    } else if (triggerType === 'date') {
       return JobService.DATE_KEYS;
-    } else if (triggerType === "file") {
+    } else if (triggerType === 'file') {
       return [];
     } else {
-      let requiredKeys = [];
-      for (let key of JobService.INTERVAL_KEYS) {
+      const requiredKeys = [];
+      for (const key of JobService.INTERVAL_KEYS) {
         if (
           ![
-            "interval_start_date",
-            "interval_end_date",
-            "interval_timezone",
-            "interval_jitter",
-            "interval_reschedule_on_finish",
+            'interval_start_date',
+            'interval_end_date',
+            'interval_timezone',
+            'interval_jitter',
+            'interval_reschedule_on_finish',
           ].includes(key)
         ) {
           requiredKeys.push(key);
@@ -296,202 +296,202 @@ export default function jobService($http, NamespaceService) {
   };
 
   JobService.SCHEMA = {
-    type: "object",
-    required: ["trigger_type", "name"],
+    type: 'object',
+    required: ['trigger_type', 'name'],
     properties: {
       trigger_type: {
-        title: "Trigger Type",
-        description: "The type of trigger to create.",
-        type: "string",
+        title: 'Trigger Type',
+        description: 'The type of trigger to create.',
+        type: 'string',
         enum: JobService.TRIGGER_TYPES,
       },
       name: {
-        title: "Job Name",
-        description: "A non-unique name for this job.",
-        type: "string",
+        title: 'Job Name',
+        description: 'A non-unique name for this job.',
+        type: 'string',
         minLength: 1,
       },
       misfire_grace_time: {
-        title: "Misfire Grace Time",
-        description: "Grace time for missed jobs.",
-        type: "integer",
+        title: 'Misfire Grace Time',
+        description: 'Grace time for missed jobs.',
+        type: 'integer',
         minimum: 0,
         default: 5,
       },
       coalesce: {
-        title: "Coalesce",
-        type: "boolean",
+        title: 'Coalesce',
+        type: 'boolean',
         default: true,
       },
       max_instances: {
-        title: "Max Instances",
-        description: "Maximum number of concurrent job executions.",
-        type: "integer",
+        title: 'Max Instances',
+        description: 'Maximum number of concurrent job executions.',
+        type: 'integer',
         minimum: 1,
         default: 3,
       },
       timeout: {
-        title: "Timeout",
-        description: "Job timeout (in seconds).",
-        type: "integer",
+        title: 'Timeout',
+        description: 'Job timeout (in seconds).',
+        type: 'integer',
       },
       run_date: {
-        title: "Run Date",
-        description: "Exact time to run this job.",
-        type: ["integer", "null"],
-        format: "datetime",
+        title: 'Run Date',
+        description: 'Exact time to run this job.',
+        type: ['integer', 'null'],
+        format: 'datetime',
       },
       date_timezone: {
-        title: "Timezone",
-        description: "The timezone associated with this job.",
-        type: "string",
-        default: "UTC",
+        title: 'Timezone',
+        description: 'The timezone associated with this job.',
+        type: 'string',
+        default: 'UTC',
       },
       year: {
-        title: "Year",
-        description: "Cron year value",
-        type: "string",
-        default: "*",
+        title: 'Year',
+        description: 'Cron year value',
+        type: 'string',
+        default: '*',
       },
       month: {
-        title: "Month",
-        description: "Cron month value",
-        type: "string",
-        default: "1",
+        title: 'Month',
+        description: 'Cron month value',
+        type: 'string',
+        default: '1',
       },
       week: {
-        title: "Week",
-        description: "Cron week value",
-        type: "string",
-        default: "*",
+        title: 'Week',
+        description: 'Cron week value',
+        type: 'string',
+        default: '*',
       },
       day_of_week: {
-        title: "Day Of Week",
-        description: "Day of Week",
-        type: "string",
-        default: "*",
+        title: 'Day Of Week',
+        description: 'Day of Week',
+        type: 'string',
+        default: '*',
       },
       hour: {
-        title: "Hour",
-        description: "Cron hour value",
-        type: "string",
-        default: "0",
+        title: 'Hour',
+        description: 'Cron hour value',
+        type: 'string',
+        default: '0',
       },
       minute: {
-        title: "Minute",
-        description: "Cron minute value",
-        type: "string",
-        default: "0",
+        title: 'Minute',
+        description: 'Cron minute value',
+        type: 'string',
+        default: '0',
       },
       second: {
-        title: "Second",
-        description: "Cron second value",
-        type: "string",
-        default: "0",
+        title: 'Second',
+        description: 'Cron second value',
+        type: 'string',
+        default: '0',
       },
       day: {
-        title: "Day",
-        description: "Cron day value",
-        type: "string",
-        default: "1",
+        title: 'Day',
+        description: 'Cron day value',
+        type: 'string',
+        default: '1',
       },
       cron_end_date: {
-        title: "End Date",
-        description: "Date when the cron should end.",
-        type: ["integer", "null"],
-        format: "datetime",
+        title: 'End Date',
+        description: 'Date when the cron should end.',
+        type: ['integer', 'null'],
+        format: 'datetime',
       },
       cron_timezone: {
-        title: "Timezone",
-        description: "Timezone to apply to start/end date.",
-        type: "string",
-        default: "UTC",
+        title: 'Timezone',
+        description: 'Timezone to apply to start/end date.',
+        type: 'string',
+        default: 'UTC',
       },
       cron_start_date: {
-        title: "Start Date",
-        description: "Date when the cron should start.",
-        type: ["integer", "null"],
-        format: "datetime",
+        title: 'Start Date',
+        description: 'Date when the cron should start.',
+        type: ['integer', 'null'],
+        format: 'datetime',
       },
       cron_jitter: {
-        title: "Cron Jitter",
+        title: 'Cron Jitter',
         description:
-          "Advance or delay job execute by this many seconds at most.",
-        type: "integer",
+          'Advance or delay job execute by this many seconds at most.',
+        type: 'integer',
         minimum: 0,
       },
       interval_end_date: {
-        title: "End Date",
-        description: "Date when the job should end.",
-        type: ["integer", "null"],
-        format: "datetime",
+        title: 'End Date',
+        description: 'Date when the job should end.',
+        type: ['integer', 'null'],
+        format: 'datetime',
       },
       interval_timezone: {
-        title: "Timezone",
-        description: "Timezone to apply to start/end date.",
-        type: "string",
-        default: "UTC",
+        title: 'Timezone',
+        description: 'Timezone to apply to start/end date.',
+        type: 'string',
+        default: 'UTC',
       },
       interval_start_date: {
-        title: "Start Date",
-        description: "Date when the job should start.",
-        type: ["integer", "null"],
-        format: "datetime",
+        title: 'Start Date',
+        description: 'Date when the job should start.',
+        type: ['integer', 'null'],
+        format: 'datetime',
       },
       interval: {
-        title: "Interval",
-        description: "Repeat this job every X of this interval",
-        type: "string",
-        enum: ["seconds", "minutes", "hours", "days", "weeks"],
-        default: "hours",
+        title: 'Interval',
+        description: 'Repeat this job every X of this interval',
+        type: 'string',
+        enum: ['seconds', 'minutes', 'hours', 'days', 'weeks'],
+        default: 'hours',
       },
       interval_num: {
-        title: "Interval Number",
-        description: "Repeat this job every X of the interval",
-        type: "integer",
+        title: 'Interval Number',
+        description: 'Repeat this job every X of the interval',
+        type: 'integer',
         default: 1,
         minimum: 0,
       },
       interval_jitter: {
-        title: "Interval Jitter",
+        title: 'Interval Jitter',
         description:
-          "Advance or delay job execute by this many seconds at most.",
-        type: "integer",
+          'Advance or delay job execute by this many seconds at most.',
+        type: 'integer',
         minimum: 0,
       },
       interval_reschedule_on_finish: {
-        title: "Reschedule on Finish",
-        description: "Reset the interval timer when the job finishes.",
-        type: "boolean",
+        title: 'Reschedule on Finish',
+        description: 'Reset the interval timer when the job finishes.',
+        type: 'boolean',
       },
       file_pattern: {
-        title: "Pattern",
+        title: 'Pattern',
         description:
-          "File name patterns to match, supports non-extended shell-style glob pattern matching",
-        type: "array",
+          'File name patterns to match, supports non-extended shell-style glob pattern matching',
+        type: 'array',
         items: {
-          type: "string",
+          type: 'string',
         },
       },
       file_path: {
-        title: "Path",
-        description: "Directory to watch.",
-        type: "string",
+        title: 'Path',
+        description: 'Directory to watch.',
+        type: 'string',
       },
       file_recursive: {
-        title: "Recursive",
-        description: "Look more than one level deep in the directory.",
-        type: "boolean",
+        title: 'Recursive',
+        description: 'Look more than one level deep in the directory.',
+        type: 'boolean',
       },
       file_callbacks: {
-        title: "Callbacks",
-        description: "What file events should trigger the plugins?",
-        type: "object",
+        title: 'Callbacks',
+        description: 'What file events should trigger the plugins?',
+        type: 'object',
         properties: {
-          on_created: { type: "boolean" },
-          on_modified: { type: "boolean" },
-          on_moved: { type: "boolean" },
-          on_deleted: { type: "boolean" },
+          on_created: {type: 'boolean'},
+          on_modified: {type: 'boolean'},
+          on_moved: {type: 'boolean'},
+          on_deleted: {type: 'boolean'},
         },
       },
     },
@@ -499,110 +499,110 @@ export default function jobService($http, NamespaceService) {
 
   JobService.FORM = [
     {
-      type: "fieldset",
-      items: ["name", "trigger_type"],
+      type: 'fieldset',
+      items: ['name', 'trigger_type'],
     },
     {
-      type: "fieldset",
+      type: 'fieldset',
       items: [
         {
-          type: "tabs",
+          type: 'tabs',
           tabs: [
             {
-              title: "Job Optional Fields",
+              title: 'Job Optional Fields',
               items: [
-                "coalesce",
-                "misfire_grace_time",
-                "max_instances",
-                "timeout",
+                'coalesce',
+                'misfire_grace_time',
+                'max_instances',
+                'timeout',
               ],
             },
             {
-              title: "Cron Trigger",
+              title: 'Cron Trigger',
               items: [
                 {
-                  type: "section",
-                  htmlClass: "row",
+                  type: 'section',
+                  htmlClass: 'row',
                   items: [
-                    { key: "minute", htmlClass: "col-md-2" },
-                    { key: "hour", htmlClass: "col-md-2" },
-                    { key: "day", htmlClass: "col-md-2" },
-                    { key: "month", htmlClass: "col-md-2" },
-                    { key: "day_of_week", htmlClass: "col-md-2" },
+                    {key: 'minute', htmlClass: 'col-md-2'},
+                    {key: 'hour', htmlClass: 'col-md-2'},
+                    {key: 'day', htmlClass: 'col-md-2'},
+                    {key: 'month', htmlClass: 'col-md-2'},
+                    {key: 'day_of_week', htmlClass: 'col-md-2'},
                   ],
                 },
                 {
-                  type: "section",
-                  htmlClass: "row",
+                  type: 'section',
+                  htmlClass: 'row',
                   items: [
-                    { key: "year", htmlClass: "col-md-3" },
-                    { key: "week", htmlClass: "col-md-3" },
-                    { key: "second", htmlClass: "col-md-3" },
-                    { key: "cron_jitter", htmlClass: "col-md-3" },
+                    {key: 'year', htmlClass: 'col-md-3'},
+                    {key: 'week', htmlClass: 'col-md-3'},
+                    {key: 'second', htmlClass: 'col-md-3'},
+                    {key: 'cron_jitter', htmlClass: 'col-md-3'},
                   ],
                 },
                 {
-                  type: "section",
-                  htmlClass: "row",
+                  type: 'section',
+                  htmlClass: 'row',
                   items: [
-                    { key: "cron_start_date", htmlClass: "col-md-4" },
-                    { key: "cron_end_date", htmlClass: "col-md-4" },
-                    { key: "cron_timezone", htmlClass: "col-md-4" },
+                    {key: 'cron_start_date', htmlClass: 'col-md-4'},
+                    {key: 'cron_end_date', htmlClass: 'col-md-4'},
+                    {key: 'cron_timezone', htmlClass: 'col-md-4'},
                   ],
                 },
               ],
             },
             {
-              title: "Interval Trigger",
+              title: 'Interval Trigger',
               items: [
                 {
-                  type: "section",
-                  htmlClass: "row",
+                  type: 'section',
+                  htmlClass: 'row',
                   items: [
-                    { key: "interval_num", htmlClass: "col-md-2" },
-                    { key: "interval", htmlClass: "col-md-2" },
-                    { key: "interval_jitter", htmlClass: "col-md-2" },
+                    {key: 'interval_num', htmlClass: 'col-md-2'},
+                    {key: 'interval', htmlClass: 'col-md-2'},
+                    {key: 'interval_jitter', htmlClass: 'col-md-2'},
                     {
-                      key: "interval_reschedule_on_finish",
-                      htmlClass: "col-md-2",
+                      key: 'interval_reschedule_on_finish',
+                      htmlClass: 'col-md-2',
                     },
                   ],
                 },
                 {
-                  type: "section",
-                  htmlClass: "row",
+                  type: 'section',
+                  htmlClass: 'row',
                   items: [
-                    { key: "interval_start_date", htmlClass: "col-md-4" },
-                    { key: "interval_end_date", htmlClass: "col-md-4" },
-                    { key: "interval_timezone", htmlClass: "col-md-4" },
+                    {key: 'interval_start_date', htmlClass: 'col-md-4'},
+                    {key: 'interval_end_date', htmlClass: 'col-md-4'},
+                    {key: 'interval_timezone', htmlClass: 'col-md-4'},
                   ],
                 },
               ],
             },
             {
-              title: "Date Trigger",
+              title: 'Date Trigger',
               items: [
                 {
-                  type: "section",
-                  htmlClass: "row",
+                  type: 'section',
+                  htmlClass: 'row',
                   items: [
-                    { key: "run_date", htmlClass: "col-md-6" },
-                    { key: "date_timezone", htmlClass: "col-md-2" },
+                    {key: 'run_date', htmlClass: 'col-md-6'},
+                    {key: 'date_timezone', htmlClass: 'col-md-2'},
                   ],
                 },
               ],
             },
             {
-              title: "File Trigger",
+              title: 'File Trigger',
               items: [
                 {
-                  type: "section",
-                  htmlClass: "row",
+                  type: 'section',
+                  htmlClass: 'row',
                   items: [
-                    { key: "file_pattern", htmlClass: "col-md-4" },
-                    { key: "file_path", htmlClass: "col-md-2" },
-                    { key: "file_recursive", htmlClass: "col-md-2" },
-                    { key: "file_callbacks", htmlClass: "col-md-2" },
+                    {key: 'file_pattern', htmlClass: 'col-md-4'},
+                    {key: 'file_path', htmlClass: 'col-md-2'},
+                    {key: 'file_recursive', htmlClass: 'col-md-2'},
+                    {key: 'file_callbacks', htmlClass: 'col-md-2'},
                   ],
                 },
               ],
@@ -612,21 +612,21 @@ export default function jobService($http, NamespaceService) {
       ],
     },
     {
-      type: "section",
-      htmlClass: "row",
+      type: 'section',
+      htmlClass: 'row',
       items: [
         {
-          type: "button",
-          style: "btn-warning w-100 ",
-          title: "Reset",
-          onClick: "reset(ngform, model, system, command.data)",
-          htmlClass: "col-md-2",
+          type: 'button',
+          style: 'btn-warning w-100 ',
+          title: 'Reset',
+          onClick: 'reset(ngform, model, system, command.data)',
+          htmlClass: 'col-md-2',
         },
         {
-          type: "submit",
-          style: "btn-primary w-100",
-          title: "Create Job",
-          htmlClass: "col-md-10",
+          type: 'submit',
+          style: 'btn-primary w-100',
+          title: 'Create Job',
+          htmlClass: 'col-md-10',
         },
       ],
     },

--- a/src/ui/src/js/services/namespace_service.js
+++ b/src/ui/src/js/services/namespace_service.js
@@ -1,4 +1,4 @@
-namespaceService.$inject = ["$stateParams"];
+namespaceService.$inject = ['$stateParams'];
 
 /**
  * namespaceService - Service for getting namespaces from the API.

--- a/src/ui/src/js/services/permission_service.js
+++ b/src/ui/src/js/services/permission_service.js
@@ -1,4 +1,4 @@
-permissionService.$inject = ["$http"];
+permissionService.$inject = ['$http'];
 
 /**
  * roleService - Service for interacting with the role API.
@@ -8,7 +8,7 @@ permissionService.$inject = ["$http"];
 export default function permissionService($http) {
   return {
     getPermissions: () => {
-      return $http.get("api/v1/permissions/");
+      return $http.get('api/v1/permissions/');
     },
   };
 }

--- a/src/ui/src/js/services/queue_service.js
+++ b/src/ui/src/js/services/queue_service.js
@@ -1,4 +1,4 @@
-queueService.$inject = ["$http"];
+queueService.$inject = ['$http'];
 
 /**
  * queueService - Service for intereacting with the QueueAPI
@@ -8,16 +8,16 @@ queueService.$inject = ["$http"];
 export default function queueService($http) {
   return {
     getQueues: (success, error) => {
-      return $http.get("api/v1/queues");
+      return $http.get('api/v1/queues');
     },
     clearQueues: () => {
-      return $http.delete("api/v1/queues");
+      return $http.delete('api/v1/queues');
     },
     clearQueue: (name) => {
-      return $http.delete("api/v1/queues/" + name);
+      return $http.delete('api/v1/queues/' + name);
     },
-    getInstanceQueues: (instance_id) => {
-      return $http.get("api/v1/instances/" + instance_id + "/queues");
+    getInstanceQueues: (instanceId) => {
+      return $http.get('api/v1/instances/' + instanceId + '/queues');
     },
   };
 }

--- a/src/ui/src/js/services/request_service.js
+++ b/src/ui/src/js/services/request_service.js
@@ -1,6 +1,6 @@
-import _ from "lodash";
+import _ from 'lodash';
 
-requestService.$inject = ["$q", "$http", "$interval"];
+requestService.$inject = ['$q', '$http', '$interval'];
 
 /**
  * requestService - Service for accessing the Request API.
@@ -10,14 +10,14 @@ requestService.$inject = ["$q", "$http", "$interval"];
  * @return {Object}                   An Object for interacting with the Request API.
  */
 export default function requestService($q, $http, $interval) {
-  const completeStatuses = ["SUCCESS", "ERROR", "CANCELED", "INVALID"];
+  const completeStatuses = ['SUCCESS', 'ERROR', 'CANCELED', 'INVALID'];
 
-  let service = {
+  const service = {
     getRequests: (data) => {
-      return $http.get("api/v1/requests", { params: data });
+      return $http.get('api/v1/requests', {params: data});
     },
     getRequest: (id) => {
-      return $http.get("api/v1/requests/" + id);
+      return $http.get('api/v1/requests/' + id);
     },
     isComplete: (request) => {
       return _.includes(completeStatuses, request.status);
@@ -28,48 +28,48 @@ export default function requestService($q, $http, $interval) {
     createRequest: (request, waitForCompletion, isFormData) => {
       let promise = undefined;
       if (isFormData) {
-        promise = $http.post("api/v1/requests", request, {
+        promise = $http.post('api/v1/requests', request, {
           headers: {
-            "Content-Type": undefined,
+            'Content-Type': undefined,
           },
         });
       } else {
-        promise = $http.post("api/v1/requests", request);
+        promise = $http.post('api/v1/requests', request);
       }
 
       if (!waitForCompletion) {
         return promise;
       }
 
-      let deferred = $q.defer();
+      const deferred = $q.defer();
       promise.then(
-        (response) => {
-          let maxTries = 60;
-          let curTry = 0;
+          (response) => {
+            const maxTries = 60;
+            let curTry = 0;
 
-          let inter = $interval(() => {
-            service.getRequest(response.data.id).then(
-              (response) => {
-                if (service.isComplete(response.data)) {
-                  deferred.resolve(response.data);
-                  $interval.cancel(inter);
-                }
+            const inter = $interval(() => {
+              service.getRequest(response.data.id).then(
+                  (response) => {
+                    if (service.isComplete(response.data)) {
+                      deferred.resolve(response.data);
+                      $interval.cancel(inter);
+                    }
 
-                if (curTry++ >= maxTries) {
-                  deferred.reject("Timeout expired");
-                  $interval.cancel(inter);
-                }
-              },
-              (errorResponse) => {
-                deferred.reject(errorResponse.data);
-                $interval.cancel(inter);
-              }
-            );
-          }, 500);
-        },
-        (errorResponse) => {
-          deferred.reject(errorResponse.data);
-        }
+                    if (curTry++ >= maxTries) {
+                      deferred.reject('Timeout expired');
+                      $interval.cancel(inter);
+                    }
+                  },
+                  (errorResponse) => {
+                    deferred.reject(errorResponse.data);
+                    $interval.cancel(inter);
+                  }
+              );
+            }, 500);
+          },
+          (errorResponse) => {
+            deferred.reject(errorResponse.data);
+          }
       );
 
       return deferred.promise;

--- a/src/ui/src/js/services/request_service.js
+++ b/src/ui/src/js/services/request_service.js
@@ -63,13 +63,13 @@ export default function requestService($q, $http, $interval) {
                   (errorResponse) => {
                     deferred.reject(errorResponse.data);
                     $interval.cancel(inter);
-                  }
+                  },
               );
             }, 500);
           },
           (errorResponse) => {
             deferred.reject(errorResponse.data);
-          }
+          },
       );
 
       return deferred.promise;

--- a/src/ui/src/js/services/role_service.js
+++ b/src/ui/src/js/services/role_service.js
@@ -57,7 +57,7 @@ export default function roleService($http) {
           roleId,
           _.map(permissions, (value) => {
             return {operation: 'add', path: '/permissions', value: value};
-          })
+          }),
       );
     },
     removePermissions: (roleId, permissions) => {
@@ -65,7 +65,7 @@ export default function roleService($http) {
           roleId,
           _.map(permissions, (value) => {
             return {operation: 'remove', path: '/permissions', value: value};
-          })
+          }),
       );
     },
     setPermissions: (roleId, permissions) => {
@@ -78,7 +78,7 @@ export default function roleService($http) {
           roleId,
           _.map(roles, (value) => {
             return {operation: 'add', path: '/roles', value: value};
-          })
+          }),
       );
     },
     removeRoles: (roleId, roles) => {
@@ -86,7 +86,7 @@ export default function roleService($http) {
           roleId,
           _.map(roles, (value) => {
             return {operation: 'remove', path: '/roles', value: value};
-          })
+          }),
       );
     },
     setRoles: (roleId, roles) => {

--- a/src/ui/src/js/services/role_service.js
+++ b/src/ui/src/js/services/role_service.js
@@ -1,6 +1,6 @@
-import _ from "lodash";
+import _ from 'lodash';
 
-roleService.$inject = ["$http"];
+roleService.$inject = ['$http'];
 
 /**
  * roleService - Service for interacting with the role API.
@@ -8,21 +8,21 @@ roleService.$inject = ["$http"];
  * @return {Object}      Service for interacting with the role API.
  */
 export default function roleService($http) {
-  let service = {
+  const service = {
     getRole: (roleId) => {
-      return $http.get("api/v1/roles/" + roleId);
+      return $http.get('api/v1/roles/' + roleId);
     },
     deleteRole: (roleId) => {
-      return $http.delete("api/v1/roles/" + roleId);
+      return $http.delete('api/v1/roles/' + roleId);
     },
     updateRole: (roleId, operations) => {
-      return $http.patch("api/v1/roles/" + roleId, { operations: operations });
+      return $http.patch('api/v1/roles/' + roleId, {operations: operations});
     },
     getRoles: () => {
-      return $http.get("api/v1/roles/");
+      return $http.get('api/v1/roles/');
     },
     createRole: (newRole) => {
-      return $http.post("api/v1/roles/", newRole);
+      return $http.post('api/v1/roles/', newRole);
     },
   };
 
@@ -39,11 +39,11 @@ export default function roleService($http) {
     let aggregateRoles = [];
     let aggregatePerms = [];
 
-    for (let role of roleList) {
+    for (const role of roleList) {
       aggregateRoles.push(role.name);
       aggregatePerms = _.union(aggregatePerms, role.permissions);
 
-      let recursed = coalescePermissions(role.roles);
+      const recursed = coalescePermissions(role.roles);
       aggregateRoles = _.union(aggregateRoles, recursed[0]);
       aggregatePerms = _.union(aggregatePerms, recursed[1]);
     }
@@ -54,44 +54,44 @@ export default function roleService($http) {
   _.assign(service, {
     addPermissions: (roleId, permissions) => {
       return service.updateRole(
-        roleId,
-        _.map(permissions, (value) => {
-          return { operation: "add", path: "/permissions", value: value };
-        })
+          roleId,
+          _.map(permissions, (value) => {
+            return {operation: 'add', path: '/permissions', value: value};
+          })
       );
     },
     removePermissions: (roleId, permissions) => {
       return service.updateRole(
-        roleId,
-        _.map(permissions, (value) => {
-          return { operation: "remove", path: "/permissions", value: value };
-        })
+          roleId,
+          _.map(permissions, (value) => {
+            return {operation: 'remove', path: '/permissions', value: value};
+          })
       );
     },
     setPermissions: (roleId, permissions) => {
       return service.updateRole(roleId, [
-        { operation: "set", path: "/permissions", value: permissions },
+        {operation: 'set', path: '/permissions', value: permissions},
       ]);
     },
     addRoles: (roleId, roles) => {
       return service.updateRole(
-        roleId,
-        _.map(roles, (value) => {
-          return { operation: "add", path: "/roles", value: value };
-        })
+          roleId,
+          _.map(roles, (value) => {
+            return {operation: 'add', path: '/roles', value: value};
+          })
       );
     },
     removeRoles: (roleId, roles) => {
       return service.updateRole(
-        roleId,
-        _.map(roles, (value) => {
-          return { operation: "remove", path: "/roles", value: value };
-        })
+          roleId,
+          _.map(roles, (value) => {
+            return {operation: 'remove', path: '/roles', value: value};
+          })
       );
     },
     setRoles: (roleId, roles) => {
       return service.updateRole(roleId, [
-        { operation: "set", path: "/roles", value: roles },
+        {operation: 'set', path: '/roles', value: roles},
       ]);
     },
     coalescePermissions: coalescePermissions,

--- a/src/ui/src/js/services/runner_service.js
+++ b/src/ui/src/js/services/runner_service.js
@@ -1,4 +1,4 @@
-runnerService.$inject = ["$http"];
+runnerService.$inject = ['$http'];
 
 /**
  * runnerService - Service for interacting with the runner API.
@@ -8,27 +8,27 @@ runnerService.$inject = ["$http"];
 export default function runnerService($http) {
   return {
     getRunner: (runnerId) => {
-      return $http.get("api/vbeta/runners/" + runnerId);
+      return $http.get('api/vbeta/runners/' + runnerId);
     },
     getRunners: () => {
-      return $http.get("api/vbeta/runners/");
+      return $http.get('api/vbeta/runners/');
     },
     startRunner: (runner) => {
-      return $http.patch("api/vbeta/runners/" + runner.id, {
-        operation: "start",
+      return $http.patch('api/vbeta/runners/' + runner.id, {
+        operation: 'start',
       });
     },
     stopRunner: (runner) => {
-      return $http.patch("api/vbeta/runners/" + runner.id, {
-        operation: "stop",
+      return $http.patch('api/vbeta/runners/' + runner.id, {
+        operation: 'stop',
       });
     },
     removeRunner: (runner) => {
-      return $http.delete("api/vbeta/runners/" + runner.id);
+      return $http.delete('api/vbeta/runners/' + runner.id);
     },
     reloadRunners: (path) => {
-      return $http.patch("api/vbeta/runners/", {
-        operation: "reload",
+      return $http.patch('api/vbeta/runners/', {
+        operation: 'reload',
         path: path,
       });
     },

--- a/src/ui/src/js/services/system_service.js
+++ b/src/ui/src/js/services/system_service.js
@@ -98,7 +98,7 @@ export default function systemService($rootScope, $http) {
     // All versions for systems with the given system name
     const versions = _.map(
         _.filter($rootScope.systems, {name: system.name}),
-        _.property('version')
+        _.property('version'),
     );
 
     // Sorted according to the system comparison function

--- a/src/ui/src/js/services/system_service.js
+++ b/src/ui/src/js/services/system_service.js
@@ -1,4 +1,4 @@
-systemService.$inject = ["$rootScope", "$http"];
+systemService.$inject = ['$rootScope', '$http'];
 
 /**
  * Compare two system versions. Intended to be used for sorting.
@@ -14,15 +14,15 @@ systemService.$inject = ["$rootScope", "$http"];
  * @param {string} version2 - second version
  * @return {int} - result of comparison
  */
-const compareVersions = function (version1, version2) {
-  let parts1 = version1.split(".");
-  let parts2 = version2.split(".");
+const compareVersions = function(version1, version2) {
+  const parts1 = version1.split('.');
+  const parts2 = version2.split('.');
 
-  let numParts = Math.min(parts1.length, parts2.length);
+  const numParts = Math.min(parts1.length, parts2.length);
 
   for (let i = 0; i < numParts; i++) {
-    let intPart1 = parseInt(parts1[i]);
-    let intPart2 = parseInt(parts2[i]);
+    const intPart1 = parseInt(parts1[i]);
+    const intPart2 = parseInt(parts2[i]);
 
     if (!isNaN(intPart1) && !isNaN(intPart2)) {
       if (intPart1 > intPart2) {
@@ -55,14 +55,14 @@ const compareVersions = function (version1, version2) {
  * @return {Object}                   Object for interacting with the system API.
  */
 export default function systemService($rootScope, $http) {
-  let service = {
+  const service = {
     getSystem: (id, options = {}) => {
-      return $http.get("api/v1/systems/" + id, {
-        params: { include_commands: options.includeCommands },
+      return $http.get('api/v1/systems/' + id, {
+        params: {include_commands: options.includeCommands},
       });
     },
     getSystems: (options = {}, headers = {}) => {
-      return $http.get("api/v1/systems", {
+      return $http.get('api/v1/systems', {
         params: {
           dereference_nested: options.dereferenceNested,
           include_fields: options.includeFields,
@@ -73,18 +73,18 @@ export default function systemService($rootScope, $http) {
       });
     },
     deleteSystem: (system) => {
-      return $http.delete("api/v1/systems/" + system.id);
+      return $http.delete('api/v1/systems/' + system.id);
     },
     forceDeleteSystem: (system) => {
-      return $http.delete("api/v1/systems/" + system.id, {
-        params: { force: true },
+      return $http.delete('api/v1/systems/' + system.id, {
+        params: {force: true},
       });
     },
     reloadSystem: (system) => {
-      return $http.patch("api/v1/systems/" + system.id, {
-        operation: "reload",
-        path: "",
-        value: "",
+      return $http.patch('api/v1/systems/' + system.id, {
+        operation: 'reload',
+        path: '',
+        value: '',
       });
     },
   };
@@ -94,17 +94,17 @@ export default function systemService($rootScope, $http) {
    * @param {Object} system - system for which you want the version URL.
    * @return {string} - either the system's version or 'latest'.
    */
-  service["getVersionForUrl"] = (system) => {
+  service['getVersionForUrl'] = (system) => {
     // All versions for systems with the given system name
-    let versions = _.map(
-      _.filter($rootScope.systems, { name: system.name }),
-      _.property("version")
+    const versions = _.map(
+        _.filter($rootScope.systems, {name: system.name}),
+        _.property('version')
     );
 
     // Sorted according to the system comparison function
-    let sorted = versions.sort(compareVersions);
+    const sorted = versions.sort(compareVersions);
 
-    return system.version == sorted[0] ? "latest" : system.version;
+    return system.version == sorted[0] ? 'latest' : system.version;
   };
 
   /**
@@ -112,32 +112,27 @@ export default function systemService($rootScope, $http) {
    * @param {string} systemId  - ObjectID for system.
    * @return {string} url to use for UI routing.
    */
-  service["getSystemUrl"] = (systemId) => {
-    for (let system of $rootScope.systems) {
+  service['getSystemUrl'] = (systemId) => {
+    for (const system of $rootScope.systems) {
       if (system.id == systemId) {
-        let version = service.getVersionForUrl(system);
-        return "/systems/" + system.name + "/" + version;
+        const version = service.getVersionForUrl(system);
+        return '/systems/' + system.name + '/' + version;
       }
     }
-    return "/systems";
+    return '/systems';
   };
 
   /**
    * Find the system with the specified name/version (version can just
    * be the string 'latest')
    *
-   * @param {string} name - The name of the system you wish to find.
+   * @param {string} namespace - The namespace of the system to find
+   * @param {string} name - The name of the system you wish to find
    * @param {string} version - The version you want to find (or latest)
-   * @return {Object} The latest system or undefined if it is not found.
+   * @return {Object} The latest system or undefined if it is not found
    */
-  service["findSystem"] = (namespace, name, version) => {
-    let notFound = {
-      data: { message: "No matching system" },
-      errorGroup: "system",
-      status: 404,
-    };
-
-    if (version !== "latest") {
+  service['findSystem'] = (namespace, name, version) => {
+    if (version !== 'latest') {
       return _.find($rootScope.systems, {
         namespace: namespace,
         name: name,
@@ -145,7 +140,7 @@ export default function systemService($rootScope, $http) {
       });
     }
 
-    let filteredSystems = _.filter($rootScope.systems, {
+    const filteredSystems = _.filter($rootScope.systems, {
       namespace: namespace,
       name: name,
     });
@@ -153,10 +148,10 @@ export default function systemService($rootScope, $http) {
       return undefined;
     }
 
-    let versions = _.map(filteredSystems, _.property("version"));
-    let sorted = versions.sort(compareVersions);
+    const versions = _.map(filteredSystems, _.property('version'));
+    const sorted = versions.sort(compareVersions);
 
-    return _.find(filteredSystems, { version: sorted[0] });
+    return _.find(filteredSystems, {version: sorted[0]});
   };
 
   /**
@@ -164,8 +159,8 @@ export default function systemService($rootScope, $http) {
    * @param {string} systemId - System's ObjectID
    * @return {Object} the system with this ID.
    */
-  service["findSystemByID"] = (systemId) => {
-    for (let system of $rootScope.systems) {
+  service['findSystemByID'] = (systemId) => {
+    for (const system of $rootScope.systems) {
       if (system.id === systemId) {
         return system;
       }

--- a/src/ui/src/js/services/token_service.js
+++ b/src/ui/src/js/services/token_service.js
@@ -1,6 +1,6 @@
-import _ from "lodash";
+import _ from 'lodash';
 
-tokenService.$inject = ["$http", "localStorageService"];
+tokenService.$inject = ['$http', 'localStorageService'];
 
 /**
  * tokenService - Service for interacting with the token API.
@@ -11,31 +11,31 @@ tokenService.$inject = ["$http", "localStorageService"];
 export default function tokenService($http, localStorageService) {
   const service = {
     getToken: () => {
-      return localStorageService.get("token");
+      return localStorageService.get('token');
     },
     handleToken: (token) => {
-      localStorageService.set("token", token);
-      $http.defaults.headers.common.Authorization = "Bearer " + token;
+      localStorageService.set('token', token);
+      $http.defaults.headers.common.Authorization = 'Bearer ' + token;
     },
     clearToken: () => {
-      localStorageService.remove("token");
+      localStorageService.remove('token');
       $http.defaults.headers.common.Authorization = undefined;
     },
     getRefresh: () => {
-      return localStorageService.get("refresh");
+      return localStorageService.get('refresh');
     },
     handleRefresh: (refreshToken) => {
-      localStorageService.set("refresh", refreshToken);
+      localStorageService.set('refresh', refreshToken);
     },
     clearRefresh: () => {
-      const refreshToken = localStorageService.get("refresh");
+      const refreshToken = localStorageService.get('refresh');
       if (refreshToken) {
         // It's possible the refresh token was already removed from the database
         // We usually don't care if that's the case, so set a noop error handler
-        localStorageService.remove("refresh");
+        localStorageService.remove('refresh');
         return $http
-          .post("api/v1/token/revoke", { refresh: refreshToken })
-          .catch(() => {});
+            .post('api/v1/token/revoke', {refresh: refreshToken})
+            .catch(() => {});
       }
     },
   };
@@ -43,28 +43,28 @@ export default function tokenService($http, localStorageService) {
   _.assign(service, {
     doLogin: (username, password) => {
       return $http
-        .post("/api/v1/token", {
-          username: username,
-          password: password,
-        })
-        .then((response) => {
-          service.handleRefresh(response.data.refresh);
-          service.handleToken(response.data.access);
-        });
+          .post('/api/v1/token', {
+            username: username,
+            password: password,
+          })
+          .then((response) => {
+            service.handleRefresh(response.data.refresh);
+            service.handleToken(response.data.access);
+          });
     },
     doRefresh: (refreshToken) => {
       return $http
-        .post("/api/v1/token/refresh", { refresh: refreshToken })
-        .then(
-          (response) => {
-            service.handleRefresh(response.data.refresh);
-            service.handleToken(response.data.access);
-          },
-          (response) => {
-            service.clearRefresh();
-            service.clearToken();
-          }
-        );
+          .post('/api/v1/token/refresh', {refresh: refreshToken})
+          .then(
+              (response) => {
+                service.handleRefresh(response.data.refresh);
+                service.handleToken(response.data.access);
+              },
+              (response) => {
+                service.clearRefresh();
+                service.clearToken();
+              }
+          );
     },
   });
 

--- a/src/ui/src/js/services/token_service.js
+++ b/src/ui/src/js/services/token_service.js
@@ -63,7 +63,7 @@ export default function tokenService($http, localStorageService) {
               (response) => {
                 service.clearRefresh();
                 service.clearToken();
-              }
+              },
           );
     },
   });

--- a/src/ui/src/js/services/user_service.js
+++ b/src/ui/src/js/services/user_service.js
@@ -38,7 +38,7 @@ export default function userService($http) {
           userId,
           _.map(roles, (value) => {
             return {operation: 'add', path: '/roles', value: value};
-          })
+          }),
       );
     },
     removeRoles: (userId, roles) => {
@@ -46,7 +46,7 @@ export default function userService($http) {
           userId,
           _.map(roles, (value) => {
             return {operation: 'remove', path: '/roles', value: value};
-          })
+          }),
       );
     },
     setRoles: (userId, roles) => {

--- a/src/ui/src/js/services/user_service.js
+++ b/src/ui/src/js/services/user_service.js
@@ -1,7 +1,7 @@
-import _ from "lodash";
-import jwtDecode from "jwt-decode";
+import _ from 'lodash';
+import jwtDecode from 'jwt-decode';
 
-userService.$inject = ["$http"];
+userService.$inject = ['$http'];
 
 /**
  * userService - Service for interacting with the user API.
@@ -11,21 +11,21 @@ userService.$inject = ["$http"];
 export default function userService($http) {
   const service = {
     getUser: (userName) => {
-      return $http.get("api/v1/users/" + userName);
+      return $http.get('api/v1/users/' + userName);
     },
     deleteUser: (userName) => {
-      return $http.delete("api/v1/users/" + userName);
+      return $http.delete('api/v1/users/' + userName);
     },
     updateUser: (userName, operations) => {
-      return $http.patch("api/v1/users/" + userName, {
+      return $http.patch('api/v1/users/' + userName, {
         operations: operations,
       });
     },
     getUsers: () => {
-      return $http.get("api/v1/users/");
+      return $http.get('api/v1/users/');
     },
     createUser: (userName, password) => {
-      return $http.post("api/v1/users/", {
+      return $http.post('api/v1/users/', {
         username: userName,
         password: password,
       });
@@ -35,32 +35,32 @@ export default function userService($http) {
   _.assign(service, {
     addRoles: (userId, roles) => {
       return service.updateUser(
-        userId,
-        _.map(roles, (value) => {
-          return { operation: "add", path: "/roles", value: value };
-        })
+          userId,
+          _.map(roles, (value) => {
+            return {operation: 'add', path: '/roles', value: value};
+          })
       );
     },
     removeRoles: (userId, roles) => {
       return service.updateUser(
-        userId,
-        _.map(roles, (value) => {
-          return { operation: "remove", path: "/roles", value: value };
-        })
+          userId,
+          _.map(roles, (value) => {
+            return {operation: 'remove', path: '/roles', value: value};
+          })
       );
     },
     setRoles: (userId, roles) => {
       return service.updateUser(userId, [
-        { operation: "set", path: "/roles", value: roles },
+        {operation: 'set', path: '/roles', value: roles},
       ]);
     },
 
     loadUser: (token) => {
-      return service.getUser(token ? jwtDecode(token).username : "anonymous");
+      return service.getUser(token ? jwtDecode(token).username : 'anonymous');
     },
     setTheme: (userId, theme) => {
       return service.updateUser(userId, [
-        { operation: "set", path: "/preferences/theme", value: theme },
+        {operation: 'set', path: '/preferences/theme', value: theme},
       ]);
     },
   });

--- a/src/ui/src/js/services/utility_service.js
+++ b/src/ui/src/js/services/utility_service.js
@@ -1,18 +1,18 @@
 export function responseState(response) {
   if (_.isUndefined(response)) {
-    return "loading";
+    return 'loading';
   }
 
   switch (response.status) {
     case 200:
       if (!_.isEmpty(response.data)) {
-        return "success";
+        return 'success';
       }
     // Fall through
     case 404:
-      return "empty";
+      return 'empty';
     default:
-      return "error";
+      return 'error';
   }
 }
 
@@ -24,8 +24,8 @@ export function responseState(response) {
  * @return {Object}             Object with name -> boolean mapping
  */
 export function arrayToMap(array, allPossible) {
-  let map = {};
-  for (let itemName of allPossible) {
+  const map = {};
+  for (const itemName of allPossible) {
     map[itemName] = _.indexOf(array, itemName) !== -1;
   }
   return map;
@@ -39,30 +39,30 @@ export function arrayToMap(array, allPossible) {
  */
 export function mapToArray(map) {
   return _.transform(
-    map,
-    (accumulator, value, key, obj) => {
-      if (value) {
-        accumulator.push(key);
-      }
-    },
-    []
+      map,
+      (accumulator, value, key, obj) => {
+        if (value) {
+          accumulator.push(key);
+        }
+      },
+      []
   );
 }
 
 export function camelCaseKeys(o) {
   if (o instanceof Array) {
-    return o.map(function (value) {
-      if (typeof value === "object") {
+    return o.map(function(value) {
+      if (typeof value === 'object') {
         value = camelCaseKeys(value);
       }
       return value;
     });
   } else {
-    let newO = {};
+    const newO = {};
     for (const origKey in o) {
       if (o.hasOwnProperty(origKey)) {
-        let value = o[origKey];
-        let newKey = origKey.replace(/(\_\w)/g, function (m) {
+        const value = o[origKey];
+        const newKey = origKey.replace(/(\_\w)/g, function(m) {
           return m[1].toUpperCase();
         });
         newO[newKey] = value;
@@ -73,18 +73,18 @@ export function camelCaseKeys(o) {
 }
 
 export function escapeHtml(html) {
-  let re = /[&<>"'/]/g;
-  let entityMap = {
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    '"': "&quot;",
-    "'": "&#39;",
-    "/": "&#x2F;",
+  const re = /[&<>"'/]/g;
+  const entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    '\'': '&#39;',
+    '/': '&#x2F;',
   };
 
   if (html) {
-    return String(html).replace(re, function (s) {
+    return String(html).replace(re, function(s) {
       return entityMap[s];
     });
   }
@@ -101,8 +101,8 @@ export function formatJsonDisplay(_editor, readOnly) {
     showLineNumbers: false,
     showPrintMargin: false,
   });
-  _editor.setTheme("ace/theme/dawn");
-  _editor.session.setMode("ace/mode/json");
+  _editor.setTheme('ace/theme/dawn');
+  _editor.session.setMode('ace/mode/json');
   _editor.session.setUseWrapMode(true);
   _editor.session.setUseWorker(!readOnly);
   _editor.$blockScrolling = Infinity;
@@ -118,7 +118,7 @@ export function formatDate(timestamp) {
   }
 }
 
-utilityService.$inject = ["$rootScope", "$http"];
+utilityService.$inject = ['$rootScope', '$http'];
 
 /**
  * utilityService - Used for getting configurations/icons and formatting
@@ -129,13 +129,13 @@ utilityService.$inject = ["$rootScope", "$http"];
 export default function utilityService($rootScope, $http) {
   return {
     getConfig: () => {
-      return $http.get("config");
+      return $http.get('config');
     },
     getVersion: () => {
-      return $http.get("version");
+      return $http.get('version');
     },
     getNamespaces: () => {
-      return $http.get("api/v1/namespaces");
+      return $http.get('api/v1/namespaces');
     },
     getIcon: (iconName) => {
       if (iconName === undefined || iconName == null) {
@@ -143,13 +143,13 @@ export default function utilityService($rootScope, $http) {
           $rootScope.config === undefined ||
           $rootScope.config.iconDefault === undefined
         ) {
-          return "";
+          return '';
         } else {
           iconName = $rootScope.config.iconDefault;
         }
       }
 
-      return iconName.substring(0, iconName.indexOf("-")) + " " + iconName;
+      return iconName.substring(0, iconName.indexOf('-')) + ' ' + iconName;
     },
   };
 }

--- a/src/ui/src/js/services/utility_service.js
+++ b/src/ui/src/js/services/utility_service.js
@@ -45,7 +45,7 @@ export function mapToArray(map) {
           accumulator.push(key);
         }
       },
-      []
+      [],
   );
 }
 

--- a/src/ui/src/partials/admin_garden_index.html
+++ b/src/ui/src/partials/admin_garden_index.html
@@ -68,7 +68,7 @@
 
         <button type="button" class="btn btn-primary btn-lg btn-block"
                 ng-click="editGarden(garden)" style="...">
-          Edit {{garden.name}} configurations
+          Edit {{garden.name}} configuration
         </button>
         <button type="button" class="btn btn-danger btn-lg btn-block"
                 ng-click="deleteGarden(garden.name)" style="..."

--- a/src/ui/src/partials/admin_garden_view.html
+++ b/src/ui/src/partials/admin_garden_view.html
@@ -70,7 +70,22 @@
   </div>
 
   <div ng-hide="isLocal">
-    <h4>Update Connection</h4>
+    <h4>
+      Update Connection
+      <button type="button"
+            class="btn btn-primary pull-right"
+            ng-controller="JobImportController"
+            ng-click="openImportJobsPopup()">
+      Import Connection
+    </button>
+    <button type="button"
+            ng-if="responseState(response) === 'success'"
+            class="btn btn-primary pull-right"
+            ng-controller="JobExportController"
+            ng-click="exportAllJobs()">
+      Export Connection
+    </button>
+    </h4>
     <div class="container-fluid">
       <div class="row">
         <form
@@ -78,7 +93,8 @@
             sf-schema="gardenSchema"
             sf-form="gardenForm"
             sf-model="gardenModel"
-            ng-submit="submitGardenForm(gardenform, gardenModel)"/>
+            ng-submit="submitGardenForm(gardenform, gardenModel)">
+        </form>
       </div>
     </div>
   </div>

--- a/src/ui/src/partials/admin_garden_view.html
+++ b/src/ui/src/partials/admin_garden_view.html
@@ -74,15 +74,16 @@
       Update Connection
       <button type="button"
             class="btn btn-primary pull-right"
-            ng-controller="JobImportController"
-            ng-click="openImportJobsPopup()">
+            ng-controller="GardenConfigImportController"
+            ng-click="openImportGardenConfigPopup()">
       Import Connection
     </button>
     <button type="button"
+            title="Export the connection as defined on the Beer Garden server"
             ng-if="responseState(response) === 'success'"
             class="btn btn-primary pull-right"
-            ng-controller="JobExportController"
-            ng-click="exportAllJobs()">
+            ng-controller="GardenConfigExportController"
+            ng-click="exportGardenConfig(data.name)">
       Export Connection
     </button>
     </h4>

--- a/src/ui/src/partials/job_index.html
+++ b/src/ui/src/partials/job_index.html
@@ -41,7 +41,6 @@
     <br />
     <p>
       <div class="btn-group d-flex w-100" role="group">
-        <!-- class="btn btn-primary btn-block btn-lg" -->
         <a role="button"
          class="btn btn-primary w-50 btn-lg"
          ui-sref="base.jobscreatesystem()">Create Your First Job</a>
@@ -52,7 +51,6 @@
         Import Jobs
       </button>
       </div>
-      
     </p>
   </div>
 </div>

--- a/src/ui/src/templates/import_garden_config.html
+++ b/src/ui/src/templates/import_garden_config.html
@@ -1,0 +1,34 @@
+<form ng-submit="doImport()">
+  <div class="modal-header">
+    <h3 class="modal-title" id="modal-title">Select File</h3>
+  </div>
+  
+  <div class="modal-body" id="modal-body">
+      <p><span class="glyphicon glyphicon-info-sign fa-2x"></span> The config selected here will update the form, but the <i>Save Configuration</i> button must be pressed to update the Beer Garden server.</p>
+    <div class="alert alert-danger" role="alert" ng-hide="fileIsGoodJson">
+      <p class="mb-0">Couldn't parse as JSON.</p>
+    </div>
+    <input type="file" id="fileSelectHiddenControl" class="file-input" style="visibility:hidden;" custom-on-change="onFileSelected">
+    
+    <div class="input-group col-xs-12">
+      <input type="text" class="form-control input-lg" disabled placeholder="{{fileName || 'Select File'}}" />
+      <span class="input-group-btn">
+        <button class="btn btn-primary input-lg" type="button" ng-click="inputClicker()">
+          <i class="glyphicon glyphicon-search"></i> Browse</button>
+      </span>
+    </div>
+  </div>
+  
+  <div class="modal-footer">
+    <input type="button"
+            class="btn btn-danger"
+            value="Cancel"
+            ng-click="cancelImport()" />
+    <input type="submit"
+            class="btn btn-success"
+            value="Import"
+            ng-disabled="!(fileContents && fileIsGoodJson)"
+            ng-click="doImport()" />
+  </div>
+
+</form>


### PR DESCRIPTION
### Overview
There are five commits in this PR to be concerned with:

1. **Typo**: A single misspelt word in a Python string. *Safe to ignore.*
2. **Massive eslint refactor**: These changes are *mostly* automatically fixed via `eslint`. Care was taken to ensure the correct version of `eslint` was used with the correct `.eslintrc.json` file. How we came to the place where there were thousands of errors is unknown, but the easy fixes are in place with this commit. There are further corrections that need to be made by hand and will occur in a later commit. *Should be safe to trust*.
3. **Alter UI to work with server data validation**: *recommend testing in conjunction with commit 4*
    a. Testing revealed that `GardenBaseSchema` was returning error messages that were not useful in their current state (strings with single quotes embedded in them don't play well with JSON).
    b. Code was added to disallow updating a garden to have no connection parameters at all.
    c. Code was added to interpret error messages received because of missing non-optional parameters and update the UI with that information.
4. **Add import/export buttons & functionality**: as the name says
5. **Fixed remaining eslint errors**. *Should be safe to trust*.


### Testing
1. We assume testing commences from commit 4 or 5. Using the usual methods, start parent and child instances of beer garden.
2. Access the garden view page for the child garden.
3. Set the connection type to *HTTP* and update the *Host Name* and  *Port* fields to their correct values (e.g., *bg-child1* and *2447*).
4. Select the *Export Connection* button. Examine the JSON file saved to the local file system to verify it is a faithful representation of the updates to the form.
5. Delete all fields for HTTP (*Host Name*, *Port* and *URL Prefix*). Press the *Save Configuration* button. Note that the UI updates with an appropriate error message about not allowing both HTTP and Stomp configuration to be empty.
6. Select the *Import Connection* button and chose the JSON file that was just saved. Note that the UI updates with the previous values for the connection.
7. Again select the "Save Configuration" button. Note that the previous error message is cleared. Use the "Sync" button to verify that the garden configuration has been updated on the server (or examine the database directly).
8. Set the *Port* to a disallowed value (e.g. zero or a negative number). Again select the "Save Configuration" button. Note that the UI updates to show that there is an error in the HTTP configuration (this would be useful if you had selected the STOMP tab before pressing the button). Note that on the HTTP tab there is a validation error associated with the port field and that it communicates the error actually received from the server (*Value out of range for ports* in this case).
9. Delete the *Port* field completely and choose the "Save Configuration" button again. Note that the invalidation message associated with the port field updates.
10. Reset the *Port* field to a legal value (e.g., *2447*). Set a single optional value on the Stomp tab. For example, set the *Send Destination* to a non-empty string. Choose the "Save Configuration" button again. Note that UI updates to alert of the stomp connection errors and the problematic fields are highlighted on the STOMP tab.
11. Delete the previously set stomp field so that every field on the stomp tab is blank. Select the *Connection Type* as *STOMP* and press the "Save Configuration" button again. Verify that the UI updates with a message indicating an empty connection is not allowed.
12. *Optional*: Alter the saved JSON file and reload it using the button. Verify that only the UI <ins>form</ins> is updated. In other words, there is no attempt to update the server until the "Save Configuration" button is pressed. This behavior is different from the *Import Jobs* functionality.


### Other
1. Leaving the host name blank on the http tab doesn't always produce an error. In some cases it causes the server to throw an exception (`AttributeError: 'dict' object has no attribute 'id'` from a malformed call to a logger) and in other cases it updates without issue *with the disallowed blank field*. Other times everything works as expected. This behavior is believed to not be related to this work and will be investigated under a different ticket.